### PR TITLE
add alt_connect() to core/conn.py to support alternative connection

### DIFF
--- a/xbbg/core/conn.py
+++ b/xbbg/core/conn.py
@@ -63,7 +63,7 @@ def alt_connect(max_attempt=3, auto_restart=True, **kwargs):
             raise ValueError('Received invalid value for auth_method. auth_method must be one of followings: user, app, userapp, dir, manual')
 
         sess_opts.setSessionIdentityOptions(authOptions=auth)
-        
+
     if isinstance(kwargs.get('server_host', None), str):
         sess_opts.setServerHost(serverHost=kwargs['server_host'])
 

--- a/xbbg/core/conn.py
+++ b/xbbg/core/conn.py
@@ -24,7 +24,7 @@ _CON_SYM_ = '_xcon_'
 _PORT_ = 8194
 
 
-def alt_connect(max_attempt = 3, auto_restart = True, **kwargs):
+def alt_connect(max_attempt=3, auto_restart=True, **kwargs):
     """
     Use alternative method to connect to blpapi. If a session object is passed, arguments
     max_attempt and auto_restart will be ignored.

--- a/xbbg/core/conn.py
+++ b/xbbg/core/conn.py
@@ -34,12 +34,12 @@ def alt_connect(max_attempt=3, auto_restart=True, **kwargs):
     """
     
     if isinstance(kwargs.get('sess', None), blpapi.session.Session):
-        bbg_session(sess = session)
+        bbg_session(sess=session)
         return
     
     sess_opts = blpapi.SessionOptions()
-    sess_opts.setNumStartAttempts(numStartAttempts = max_attempt)
-    sess_opts.setAutoRestartOnDisconnection(autoRestart = auto_restart)
+    sess_opts.setNumStartAttempts(numStartAttempts=max_attempt)
+    sess_opts.setAutoRestartOnDisconnection(autoRestart=auto_restart)
 
     if isinstance(kwargs.get('auth_method', None), str):
         auth_method = kwargs['auth_method']
@@ -47,34 +47,34 @@ def alt_connect(max_attempt=3, auto_restart=True, **kwargs):
         
         if auth_method == 'user':
             user = blpapi.AuthUser.createWithLogonName()
-            auth = blpapi.AuthOptions.createWithUser(user = user)
+            auth = blpapi.AuthOptions.createWithUser(user=user)
         elif auth_method == 'app':
-            auth = blpapi.AuthOptions.createWithApp(appName = kwargs['app_name'])
+            auth = blpapi.AuthOptions.createWithApp(appName=kwargs['app_name'])
         elif auth_method == 'userapp':
             user = blpapi.createWithLogonName()
-            auth = blpapi.AuthOptions.createWithUserAndApp(user = user, appName = kwargs['app_name'])
+            auth = blpapi.AuthOptions.createWithUserAndApp(user=user, appName=kwargs['app_name'])
         elif auth_method == 'dir':
-            user = blpapi.AuthUser.createWithActiveDirectoryProperty(propertyName= kwargs['dir_property'])
-            auth = blpapi.AuthOptions.createWithUser(user = user)
+            user = blpapi.AuthUser.createWithActiveDirectoryProperty(propertyName=kwargs['dir_property'])
+            auth = blpapi.AuthOptions.createWithUser(user=user)
         elif auth_method == 'manual':
-            user = blpapi.AuthUser.createWithManualOptions(userId= kwargs['user_id'], ipAddress=kwargs['ip_address'])
-            auth = blpapi.AuthOptions.createWithUserAndApp(user = user, appName = kwargs['app_name'])
+            user = blpapi.AuthUser.createWithManualOptions(userId=kwargs['user_id'], ipAddress=kwargs['ip_address'])
+            auth = blpapi.AuthOptions.createWithUserAndApp(user=user, appName=kwargs['app_name'])
         else:
             raise ValueError('Received invalid value for auth_method. auth_method must be one of followings: user, app, userapp, dir, manual')
         
-        sess_opts.setSessionIdentityOptions(authOptions = auth)
+        sess_opts.setSessionIdentityOptions(authOptions=auth)
         
     if isinstance(kwargs.get('server_host', None), str):
-        sess_opts.setServerHost(serverHost = kwargs['server_host'])
+        sess_opts.setServerHost(serverHost=kwargs['server_host'])
 
     if isinstance(kwargs.get('server_port', None), str):
-        sess_opts.setServerPort(serverPort = kwargs['server_post'])
+        sess_opts.setServerPort(serverPort=kwargs['server_post'])
         
     if isinstance(kwargs.get('tls_options', None), blpapi.sessionoptions.TlsOptions):
-        sess_opts.setTlsOptions(tlsOptions = kwargs['tlsOptions'])
+        sess_opts.setTlsOptions(tlsOptions=kwargs['tlsOptions'])
 
     session = blpapi.Session(sess_opts)
-    bbg_session(sess = session)
+    bbg_session(sess=session)
 
 
 def connect_bbg(**kwargs) -> blpapi.session.Session:

--- a/xbbg/core/conn.py
+++ b/xbbg/core/conn.py
@@ -32,11 +32,11 @@ def alt_connect(max_attempt=3, auto_restart=True, **kwargs):
     referecing to blpapi example for full lists of available authentication methods:
         https://github.com/msitt/blpapi-python/blob/master/examples/ConnectionAndAuthExample.py
     """
-    
+
     if isinstance(kwargs.get('sess', None), blpapi.session.Session):
         bbg_session(sess=kwargs['sess'])
         return
-    
+
     sess_opts = blpapi.SessionOptions()
     sess_opts.setNumStartAttempts(numStartAttempts=max_attempt)
     sess_opts.setAutoRestartOnDisconnection(autoRestart=auto_restart)
@@ -44,7 +44,7 @@ def alt_connect(max_attempt=3, auto_restart=True, **kwargs):
     if isinstance(kwargs.get('auth_method', None), str):
         auth_method = kwargs['auth_method']
         auth = None
-        
+
         if auth_method == 'user':
             user = blpapi.AuthUser.createWithLogonName()
             auth = blpapi.AuthOptions.createWithUser(user=user)
@@ -61,7 +61,7 @@ def alt_connect(max_attempt=3, auto_restart=True, **kwargs):
             auth = blpapi.AuthOptions.createWithUserAndApp(user=user, appName=kwargs['app_name'])
         else:
             raise ValueError('Received invalid value for auth_method. auth_method must be one of followings: user, app, userapp, dir, manual')
-        
+
         sess_opts.setSessionIdentityOptions(authOptions=auth)
         
     if isinstance(kwargs.get('server_host', None), str):
@@ -69,7 +69,7 @@ def alt_connect(max_attempt=3, auto_restart=True, **kwargs):
 
     if isinstance(kwargs.get('server_port', None), str):
         sess_opts.setServerPort(serverPort=kwargs['server_post'])
-        
+
     if isinstance(kwargs.get('tls_options', None), blpapi.sessionoptions.TlsOptions):
         sess_opts.setTlsOptions(tlsOptions=kwargs['tlsOptions'])
 

--- a/xbbg/core/conn.py
+++ b/xbbg/core/conn.py
@@ -34,7 +34,7 @@ def alt_connect(max_attempt=3, auto_restart=True, **kwargs):
     """
     
     if isinstance(kwargs.get('sess', None), blpapi.session.Session):
-        bbg_session(sess=session)
+        bbg_session(sess=kwargs['sess'])
         return
     
     sess_opts = blpapi.SessionOptions()

--- a/xbbg/core/conn.py
+++ b/xbbg/core/conn.py
@@ -28,7 +28,7 @@ def alt_connect(max_attempt=3, auto_restart=True, **kwargs):
     """
     Use alternative method to connect to blpapi. If a session object is passed, arguments
     max_attempt and auto_restart will be ignored.
-    
+
     referecing to blpapi example for full lists of available authentication methods:
         https://github.com/msitt/blpapi-python/blob/master/examples/ConnectionAndAuthExample.py
     """


### PR DESCRIPTION
Added alt_connect() function in core/conn.py to support different authentication methods to connect to blpapi.
If a user is simply connecting with desktop api (the default method), then there will be no need to call alt_connect().
If a user is using other authentication method (Sever API/ anything else), then user can call alt_connect first to create the connection. 

I am only able to tested this with bloomberg Server API authentication and it's working. For completeness, I also adapted other authentication methods listed in blpapi's sample script:  https://github.com/msitt/blpapi-python/blob/master/examples/ConnectionAndAuthExample.py (further testing will be required.)
