### PR TITLE
Added functionality to custom config usage in bdib

### DIFF
--- a/xbbg/const.py
+++ b/xbbg/const.py
@@ -160,7 +160,7 @@ def exch_info(ticker: str, **kwargs) -> pd.Series:
         Series([], dtype: object)
     """
     logger = logs.get_logger(exch_info, level='debug')
-    
+
     if kwargs.get('ref', '') and kwargs.get('config') is not None:
         return exch_info(ticker=kwargs['ref'], config=kwargs['config'])
     elif kwargs.get('ref', ''):

--- a/xbbg/const.py
+++ b/xbbg/const.py
@@ -161,10 +161,8 @@ def exch_info(ticker: str, **kwargs) -> pd.Series:
     """
     logger = logs.get_logger(exch_info, level='debug')
 
-    if kwargs.get('ref', '') and kwargs.get('config') is not None:
-        return exch_info(ticker=kwargs['ref'], config=kwargs['config'])
-    elif kwargs.get('ref', ''):
-        return exch_info(ticker=kwargs['ref'])
+    if kwargs.get('ref', ''):
+        return exch_info(ticker=kwargs['ref'], **{k: v for k, v in kwargs.items() if k != 'ref'})
 
     exch = kwargs.get('config', param.load_config(cat='exch'))
     original = kwargs.get('original', '')

--- a/xbbg/const.py
+++ b/xbbg/const.py
@@ -160,8 +160,10 @@ def exch_info(ticker: str, **kwargs) -> pd.Series:
         Series([], dtype: object)
     """
     logger = logs.get_logger(exch_info, level='debug')
-
-    if kwargs.get('ref', ''):
+    
+    if kwargs.get('ref', '') and kwargs.get('config') is not None:
+        return exch_info(ticker=kwargs['ref'], config=kwargs['config'])
+    elif kwargs.get('ref', ''):
         return exch_info(ticker=kwargs['ref'])
 
     exch = kwargs.get('config', param.load_config(cat='exch'))


### PR DESCRIPTION
Issue: when using a ref argument in exch_info (from bdib) and a config arg for other markets not listed in exch.yml, the dataframe passed to the config argument was omitted in the recurring call for exch_info on line 164.

Solution: add additional if statement that if config argument is used, pass this to the recurring call in addition to the ref argument