### PR TITLE
Fixing typo in TLS Options when creating a new connection

### DIFF
--- a/xbbg/core/conn.py
+++ b/xbbg/core/conn.py
@@ -72,7 +72,7 @@ def connect(max_attempt=3, auto_restart=True, **kwargs) -> blpapi.session.Sessio
         sess_opts.setServerPort(serverPort=kwargs['server_port'])
 
     if isinstance(kwargs.get('tls_options', None), blpapi.sessionoptions.TlsOptions):
-        sess_opts.setTlsOptions(tlsOptions=kwargs['tlsOptions'])
+        sess_opts.setTlsOptions(tlsOptions=kwargs['tls_options'])
 
     return bbg_session(sess=blpapi.Session(sess_opts))
 


### PR DESCRIPTION
Fixed minor typo in TLS Options. Now users can only pass `tls_options` keyword whereas previously they would have had to pass both `tls_options` and `tlsOptions`. 