### PR TITLE
Fixing Auto CI

### DIFF
--- a/.github/workflows/auto_ci.yml
+++ b/.github/workflows/auto_ci.yml
@@ -8,13 +8,16 @@ on:
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     env:
       BLPAPI_ROOT: /home/bbg
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8"]
+        python-version: ["3.6.15", "3.7.17", "3.8.18"]
+        os: [ubuntu-latest, ubuntu-20.04]
+        exclude:
+          - python-version: "3.6.15"
+            os: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 -i https://pypi.org/simple
 --extra-index-url https://bcms.bloomberg.com/pip/simple/
 numpy >= 1.15.0
-pandas >= 1.0.0
+pandas >= 1.0.0, <=1.5.3
 pyarrow >= 1.0.1
 pytz >= 2020.4
 ruamel.yaml >= 0.15.0


### PR DESCRIPTION
There were two reasons why AutoCI broke:

1. Since ubuntu-latest changed from 20.04 to 22.04 the python-3.6 no longer works. See this [this](https://github.com/actions/setup-python/issues/543) more details. 
2. After pandas 1.3.5 the behaviour of pd.to_datetime changed when given a dataframe. We rely on this behaviour at least in the format_raw mehod in pipeline.py 

Please let me know if  solutions different from the ones implemented would be preferred. 