### PR TITLE
fix(live): make blp.live truly async using asyncio.Queue

### DIFF
--- a/xbbg/blp.py
+++ b/xbbg/blp.py
@@ -603,7 +603,6 @@ async def live(tickers, flds=None, info=None, max_cnt=0, options=None, **kwargs)
     if info is None: info = const.LIVE_INFO
 
     import asyncio
-    from queue import Queue
 
     # Session options (allow host/port override via kwargs)
     sess_opts = conn.blpapi.SessionOptions()
@@ -614,7 +613,10 @@ async def live(tickers, flds=None, info=None, max_cnt=0, options=None, **kwargs)
     sess_opts.setServerPort(int(kwargs.get('server_port') or kwargs.get('port') or 8194))
 
     dispatcher = conn.blpapi.EventDispatcher(2)
-    outq: Queue = Queue()
+    # Use asyncio.Queue for truly async behavior
+    outq: asyncio.Queue = asyncio.Queue()
+    # Get the running event loop (we're in an async context)
+    loop = asyncio.get_running_loop()
 
     def _handler(event, session):  # signature: (Event, Session)
         try:
@@ -625,17 +627,20 @@ async def live(tickers, flds=None, info=None, max_cnt=0, options=None, **kwargs)
                     continue
                 if msg.getElement(fld).isNull():
                     continue
-                outq.put({
-                        **{
-                            'TICKER': msg.correlationIds()[0].value(),
-                            'FIELD': fld,
-                        },
-                        **{
-                            str(elem.name()): process.elem_value(elem)
-                            for elem in msg.asElement().elements()
-                            if (True if not info else str(elem.name()) in info)
-                        },
-                })
+                # Bridge from blpapi thread to asyncio event loop
+                data = {
+                    **{
+                        'TICKER': msg.correlationIds()[0].value(),
+                        'FIELD': fld,
+                    },
+                    **{
+                        str(elem.name()): process.elem_value(elem)
+                        for elem in msg.asElement().elements()
+                        if (True if not info else str(elem.name()) in info)
+                    },
+                }
+                # Use call_soon_threadsafe to safely put items from handler thread
+                loop.call_soon_threadsafe(outq.put_nowait, data)
         except Exception as e:  # noqa: BLE001
             logger.debug(e)
 
@@ -654,7 +659,8 @@ async def live(tickers, flds=None, info=None, max_cnt=0, options=None, **kwargs)
         sess.subscribe(sub_list)
         cnt = 0
         while True and (max_cnt == 0 or cnt <= max_cnt):
-            item = await asyncio.to_thread(outq.get)
+            # Use async queue.get() which is truly non-blocking
+            item = await outq.get()
             yield item
             if max_cnt:
                 cnt += 1


### PR DESCRIPTION
## Summary

This PR fixes issue #101 where \lp.live\ was blocking despite being marked as \sync def\.

## Problem

The previous implementation used \queue.Queue\ with \wait asyncio.to_thread(outq.get)\, which offloaded blocking I/O to a thread pool executor. While this didn't block the event loop, it wasn't truly async and had the same performance characteristics as a synchronous version.

## Solution

- Replaced \queue.Queue\ with \syncio.Queue\ for truly async behavior
- Use \syncio.get_running_loop()\ to get the event loop
- Use \loop.call_soon_threadsafe(outq.put_nowait, data)\ to safely bridge from the blpapi EventDispatcher thread (where the handler runs) to the asyncio event loop
- Use \wait outq.get()\ instead of \wait asyncio.to_thread(outq.get)\ which is truly non-blocking

## Changes

- \live()\ now uses \syncio.Queue\ instead of \queue.Queue\
- Handler uses \call_soon_threadsafe()\ to put items into the async queue from the blpapi thread
- Main loop uses \wait outq.get()\ for truly async waiting

## Testing

The function maintains the same API and behavior, but is now truly async and non-blocking.

## References

- Fixes #101