### PR TITLE
feat: add fixed income securities support to bdib

### DIFF
--- a/xbbg/blp.py
+++ b/xbbg/blp.py
@@ -492,7 +492,7 @@ def bdib(ticker: str, dt, session='allday', typ='TRADE', **kwargs) -> pd.DataFra
         is_fixed_income = (
             ticker.startswith('/isin/') or ticker.startswith('/cusip/') or ticker.startswith('/sedol/') or
             (len(t_info) > 0 and t_info[-1] in ['Govt', 'Corp', 'Mtge', 'Muni'] and
-             t_info[0] and len(t_info[0]) == 2)  # Only if starts with country code
+             t_info[0] and len(t_info[0]) >= 2 and t_info[0][:2].isalpha())  # Only if starts with 2-letter country code
         )
         if is_fixed_income:
             ex_info = _get_default_exchange_info(ticker=ticker, dt=dt, session=session, **kwargs)


### PR DESCRIPTION
## Summary

This PR adds support for fixed income securities (government bonds, corporate bonds, etc.) to the \dib\ function.

## Changes

- **Fixed Income Detection**: Automatically detects fixed income securities by checking for asset types (Govt, Corp, Mtge, Muni) or identifier-based tickers (/isin/, /cusip/, /sedol/)
- **Default Exchange Info**: When exchange info is not available, uses default exchange info with country-code-based timezone inference
- **Time Range Handling**: Handles cases where \	ime_range\ returns None by creating default time range from exchange info

## Problem Solved

Previously, calling \dib\ with fixed income securities would raise:
\\\
KeyError: 'Cannot find exchange info for US912810FE39 Govt'
\\\

Now it works correctly:
\\\python
blp.bdib(ticker='/isin/US912810FE39', dt='2025-11-13')
\\\

## Testing

Tested with:
- US government bond: \US912810FE39 Govt\
- ISIN format: \/isin/US912810FE39\
- Both formats successfully return intraday bar data

Fixes the issue reported where \dib\ didn't support US government bonds.