### PR TITLE
feat: add bsrch() function for Bloomberg SRCH queries (Excel =@BSRCH equivalent)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ xbbg is the **most comprehensive and intuitive blpapi wrapper for Python**, prov
 
 **Why xbbg?**
 
-- 🎯 **Complete API Coverage**: Reference, historical, intraday bars, tick data, real-time subscriptions, equity screening (BEQS), and BQL support
+- 🎯 **Complete API Coverage**: Reference, historical, intraday bars, tick data, real-time subscriptions, equity screening (BEQS), BQL support, and Bloomberg SRCH queries
 - 📊 **Excel-Compatible**: Use familiar Excel date formats and field names - no learning curve
 - ⚡ **Built-in Caching**: Automatic Parquet-based local storage reduces API calls and speeds up workflows
 - 🔧 **Rich Utilities**: Currency conversion, futures/CDX resolvers, exchange-aware market hours, and more
@@ -53,6 +53,7 @@ xbbg stands out as the most comprehensive and user-friendly blpapi wrapper for P
 | Real-time Subscriptions | ✅ | ❌ | ❌ | ❌ |
 | Equity Screening (BEQS) | ✅ | ❌ | ❌ | ❌ |
 | BQL Support | ✅ | ❌ | ❌ | ❌ |
+| Bloomberg SRCH (BSRCH) | ✅ | ❌ | ❌ | ❌ |
 | Excel-compatible inputs | ✅ | ❌ | ❌ | ❌ |
 | Sub-minute intervals | ✅ | ❌ | ❌ | ❌ |
 | Local Parquet caching | ✅ | ❌ | ❌ | ❌ |
@@ -66,7 +67,7 @@ xbbg stands out as the most comprehensive and user-friendly blpapi wrapper for P
 
 **Key Advantages:**
 
-- 🎯 **Most Complete API**: Covers reference, historical, intraday, tick, real-time, screening, and BQL
+- 🎯 **Most Complete API**: Covers reference, historical, intraday, tick, real-time, screening, BQL, and Bloomberg SRCH queries
 - 📊 **Excel Compatibility**: Use familiar Excel date formats and field names
 - ⚡ **Performance**: Built-in Parquet caching reduces API calls and speeds up workflows
 - 🔧 **Rich Utilities**: Currency conversion, futures resolvers, and more out of the box
@@ -91,6 +92,7 @@ xbbg stands out as the most comprehensive and user-friendly blpapi wrapper for P
 | 🔍 **Screening & Queries** | | |
 | `beqs()` | Bloomberg Equity Screening | Custom criteria, private/public screens |
 | `bql()` | Bloomberg Query Language | SQL-like syntax, complex transformations |
+| `bsrch()` | Bloomberg SRCH (Search) | User-defined searches, commodity screens, weather data |
 | 📡 **Real-time** | | |
 | `live()` | Real-time market data | Async updates, context manager support |
 | `subscribe()` | Real-time subscriptions | Field-level subscriptions, event callbacks |
@@ -461,7 +463,50 @@ Out[14]:
 
 # Bloomberg Equity Screening (BEQS)
 # blp.beqs(screen='MyScreen', asof='2023-01-01')  # doctest: +SKIP
+
+```python
+# Bloomberg SRCH (Search) - Fixed Income example
+blp.bsrch("FI:YOURSRCH")  # doctest: +SKIP
 ```
+
+```pydocstring
+Out[16]:
+              id
+0  !!ABC123 Mtge
+1  !!DEF456 Mtge
+2  !!GHI789 Mtge
+3  !!JKL012 Mtge
+4  !!MNO345 Mtge
+```
+
+```python
+# Bloomberg SRCH - Weather data with parameters
+blp.bsrch(  # doctest: +SKIP
+    "comdty:weather",
+    overrides={
+        "provider": "wsi",
+        "location": "US_XX",
+        "model": "ACTUALS",
+        "frequency": "DAILY",
+        "target_start_date": "2021-01-01",
+        "target_end_date": "2021-01-05",
+        "location_time": "false",
+        "fields": "WIND_SPEED|TEMPERATURE|HDD_65F|CDD_65F|HDD_18C|CDD_18C|PRECIPITATION_24HR|CLOUD_COVER|FEELS_LIKE_TEMPERATURE|MSL_PRESSURE|TEMPERATURE_MAX_24HR|TEMPERATURE_MIN_24HR"
+    }
+)
+```
+
+```pydocstring
+Out[17]:
+              Reported Time  Wind Speed (m/s)  Temperature (°C)  Heating Degree Days (°F)  Cooling Degree Days (°F)
+0 2021-01-01 06:00:00+00:00              3.45              -2.15                   38.25                     0.0
+1 2021-01-02 06:00:00+00:00              2.10              -1.85                   36.50                     0.0
+2 2021-01-03 06:00:00+00:00              1.95              -2.30                   37.80                     0.0
+3 2021-01-04 06:00:00+00:00              2.40              -2.65                   38.10                     0.0
+4 2021-01-05 06:00:00+00:00              2.15              -1.20                   35.75                     0.0
+```
+
+**Note:** The `bsrch()` function uses the Bloomberg Excel service (`//blp/exrsvc`) and supports user-defined SRCH screens, commodity screens, and Bloomberg example screens. For weather data and other specialized searches, use the `overrides` parameter to pass search-specific parameters.
 
 ### 📡 Real-time
 


### PR DESCRIPTION
This PR adds support for Bloomberg SRCH queries, equivalent to Excel's `=@BSRCH` function.

## Changes
- Added `bsrch()` function in `xbbg/blp.py` using the `//blp/exrsvc` service
- Added `process_bsrch()` handler in `xbbg/core/process.py` for processing GridResponse messages
- Supports user-defined SRCH screens, commodity screens, and Bloomberg example screens
- Added `overrides` parameter for search-specific parameters (e.g., weather data)
- Documented usage in README.md with examples for fixed income and weather data

## Usage Example
```python
from xbbg import blp

# Weather data (as requested in issue #116)
weather_df = blp.bsrch(
    "comdty:weather",
    overrides={
        "provider": "wsi",
        "location": "US_IL",
        "model": "ACTUALS",
        "frequency": "DAILY",
        "target_start_date": "2021-01-01",
        "target_end_date": "2024-12-31",
        "location_time": "false",
        "fields": "WIND_SPEED|TEMPERATURE|HDD_65F|CDD_65F|HDD_18C|CDD_18C|PRECIPITATION_24HR|CLOUD_COVER|FEELS_LIKE_TEMPERATURE|MSL_PRESSURE|TEMPERATURE_MAX_24HR|TEMPERATURE_MIN_24HR"
    }
)
```

Fixes #116

