### PR TITLE
feat: Add multi-day cache support for bdib()

### DIFF
--- a/xbbg/io/cache.py
+++ b/xbbg/io/cache.py
@@ -46,7 +46,7 @@ def get_cache_root() -> str:
     global _default_cache_logged
 
     # Check if BBG_ROOT is explicitly set
-    bbg_root = os.environ.get(overrides.BBG_ROOT, '')
+    bbg_root = os.environ.get(overrides.BBG_ROOT, "")
     if bbg_root:
         return bbg_root
 
@@ -58,28 +58,28 @@ def get_cache_root() -> str:
         # Use current directory as last resort
         home = Path.cwd()
 
-    if sys.platform == 'win32':
+    if sys.platform == "win32":
         # Windows: Use APPDATA if available, otherwise use user home
-        appdata = os.environ.get('APPDATA', '')
-        default_cache = Path(appdata) / 'xbbg' if appdata else home / '.xbbg'
+        appdata = os.environ.get("APPDATA", "")
+        default_cache = Path(appdata) / "xbbg" if appdata else home / ".xbbg"
     else:
         # Linux/Mac: Use .cache directory if it exists, otherwise use .xbbg in home
-        cache_dir = home / '.cache'
-        default_cache = cache_dir / 'xbbg' if cache_dir.exists() else home / '.xbbg'
+        cache_dir = home / ".cache"
+        default_cache = cache_dir / "xbbg" if cache_dir.exists() else home / ".xbbg"
 
     # Log once when default is first used
     if not _default_cache_logged:
         logger.info(
-            'BBG_ROOT not set. Using default cache location: %s. '
-            'Set BBG_ROOT environment variable to use a custom location.',
-            default_cache
+            "BBG_ROOT not set. Using default cache location: %s. "
+            "Set BBG_ROOT environment variable to use a custom location.",
+            default_cache,
         )
         _default_cache_logged = True
 
     return str(default_cache)
 
 
-def bar_file(ticker: str, dt, typ='TRADE') -> str:
+def bar_file(ticker: str, dt, typ="TRADE") -> str:
     """Data file location for Bloomberg historical data.
 
     Args:
@@ -92,17 +92,45 @@ def bar_file(ticker: str, dt, typ='TRADE') -> str:
     """
     data_path_str = get_cache_root()
     if not data_path_str:
-        return ''
+        return ""
     data_path = Path(data_path_str)
     asset = ticker.split()[-1]
-    proper_ticker = ticker.replace('/', '_')
-    cur_dt = pd.Timestamp(dt).strftime('%Y-%m-%d')
-    return (data_path / asset / proper_ticker / typ / f'{cur_dt}.parq').as_posix()
+    proper_ticker = ticker.replace("/", "_")
+    cur_dt = pd.Timestamp(dt).strftime("%Y-%m-%d")
+    return (data_path / asset / proper_ticker / typ / f"{cur_dt}.parq").as_posix()
 
 
-def ref_file(
-        ticker: str, fld: str, has_date=False, cache=False, ext='parq', **kwargs
-) -> str:
+def multi_day_bar_files(
+    ticker: str,
+    start_datetime: str | pd.Timestamp,
+    end_datetime: str | pd.Timestamp,
+    typ: str = "TRADE",
+) -> list[tuple[str, str]]:
+    """Get list of (date_str, file_path) tuples for a multi-day range.
+
+    Args:
+        ticker: Ticker name
+        start_datetime: Start of range
+        end_datetime: End of range
+        typ: Event type
+
+    Returns:
+        List of (date_str, file_path) tuples for each day in range.
+        Returns empty list if cache root is not available.
+    """
+    data_path_str = get_cache_root()
+    if not data_path_str:
+        return []
+
+    start_dt = pd.Timestamp(start_datetime).normalize()
+    end_dt = pd.Timestamp(end_datetime).normalize()
+
+    dates = pd.date_range(start=start_dt, end=end_dt, freq="D")
+
+    return [(dt.strftime("%Y-%m-%d"), bar_file(ticker=ticker, dt=dt, typ=typ)) for dt in dates]
+
+
+def ref_file(ticker: str, fld: str, has_date=False, cache=False, ext="parq", **kwargs) -> str:
     """Data file location for Bloomberg reference data.
 
     Args:
@@ -117,33 +145,33 @@ def ref_file(
         str: File location or empty string if not cached.
     """
     if not cache:
-        return ''
+        return ""
     data_path_str = get_cache_root()
     if not data_path_str:
-        return ''
+        return ""
     data_path = Path(data_path_str)
 
-    proper_ticker = ticker.replace('/', '_')
-    cache_days = kwargs.pop('cache_days', 10)
+    proper_ticker = ticker.replace("/", "_")
+    cache_days = kwargs.pop("cache_days", 10)
     root = data_path / ticker.split()[-1] / proper_ticker / fld
 
     ref_kw = {k: v for k, v in kwargs.items() if k not in overrides.PRSV_COLS}
-    info = utils.to_str(ref_kw)[1:-1].replace('|', '_') if len(ref_kw) > 0 else 'ovrd=None'
+    info = utils.to_str(ref_kw)[1:-1].replace("|", "_") if len(ref_kw) > 0 else "ovrd=None"
 
     if has_date:
-        cache_file = (root / f'asof=[cur_date], {info}.{ext}').as_posix()
+        cache_file = (root / f"asof=[cur_date], {info}.{ext}").as_posix()
         cur_dt = utils.cur_time()
-        start_dt = pd.date_range(end=cur_dt, freq=f'{cache_days}D', periods=2)[0]
+        start_dt = pd.date_range(end=cur_dt, freq=f"{cache_days}D", periods=2)[0]
         for dt in pd.date_range(start=start_dt, end=cur_dt, normalize=True)[1:][::-1]:
-            cur_file = cache_file.replace('[cur_date]', dt.strftime("%Y-%m-%d"))
+            cur_file = cache_file.replace("[cur_date]", dt.strftime("%Y-%m-%d"))
             if files.exists(cur_file):
                 return cur_file
-        return cache_file.replace('[cur_date]', str(cur_dt))
+        return cache_file.replace("[cur_date]", str(cur_dt))
 
-    return (root / f'{info}.{ext}').as_posix()
+    return (root / f"{info}.{ext}").as_posix()
 
 
-def save_intraday(data: pd.DataFrame, ticker: str, dt, typ='TRADE', **kwargs):
+def save_intraday(data: pd.DataFrame, ticker: str, dt, typ="TRADE", **kwargs):
     """Check whether data is done for the day and save.
 
     Args:
@@ -153,33 +181,33 @@ def save_intraday(data: pd.DataFrame, ticker: str, dt, typ='TRADE', **kwargs):
         typ: [TRADE, BID, ASK, BID_BEST, ASK_BEST, BEST_BID, BEST_ASK]
         **kwargs: Additional options forwarded to timing/logging helpers.
     """
-    cur_dt = pd.Timestamp(dt).strftime('%Y-%m-%d')
-    info = f'{ticker} / {cur_dt} / {typ}'
+    cur_dt = pd.Timestamp(dt).strftime("%Y-%m-%d")
+    info = f"{ticker} / {cur_dt} / {typ}"
     data_file = bar_file(ticker=ticker, dt=dt, typ=typ)
     if not data_file:
         return
 
     if data.empty:
-        logger.warning('No data to save for %s (empty DataFrame)', info)
+        logger.warning("No data to save for %s (empty DataFrame)", info)
         return
 
     exch = const.exch_info(ticker=ticker, **kwargs)
     if exch.empty:
         return
 
-    end_time = pd.Timestamp(
-        const.market_timing(ticker=ticker, dt=dt, timing='FINISHED', **kwargs)
-    ).tz_localize(exch.tz)
-    now = pd.Timestamp('now', tz=exch.tz) - pd.Timedelta('1h')
+    end_time = pd.Timestamp(const.market_timing(ticker=ticker, dt=dt, timing="FINISHED", **kwargs)).tz_localize(exch.tz)
+    now = pd.Timestamp("now", tz=exch.tz) - pd.Timedelta("1h")
 
     if end_time > now:
-        logger.debug('Skipping save: market close time %s is less than 1 hour ago (%s), data may be incomplete', end_time, now)
+        logger.debug(
+            "Skipping save: market close time %s is less than 1 hour ago (%s), data may be incomplete", end_time, now
+        )
         return
 
     if logger.isEnabledFor(logging.INFO):
-        logger.info('Saving intraday data to cache: %s (%d rows)', data_file, len(data))
+        logger.info("Saving intraday data to cache: %s (%d rows)", data_file, len(data))
     else:
-        logger.info('Saving intraday data to cache: %s', data_file)
+        logger.info("Saving intraday data to cache: %s", data_file)
     files.create_folder(data_file, is_file=True)
     data.to_parquet(data_file)
 
@@ -198,6 +226,11 @@ class BarCacheAdapter:
         session_window: contracts.SessionWindow,
     ) -> pd.DataFrame | None:
         """Load cached bar data if available."""
+        # Handle multi-day requests
+        if request.is_multi_day():
+            return self._load_multi_day(request)
+
+        # Single-day request: require valid session window
         if not session_window.is_valid():
             return None
 
@@ -214,14 +247,92 @@ class BarCacheAdapter:
             res = (
                 pd.read_parquet(data_file)
                 .pipe(pipeline.add_ticker, ticker=request.ticker)
-                .loc[session_window.start_time:session_window.end_time]
+                .loc[session_window.start_time : session_window.end_time]
             )
 
             if not res.empty:
-                logger.debug('Loading cached Bloomberg intraday data from: %s', data_file)
+                logger.debug("Loading cached Bloomberg intraday data from: %s", data_file)
                 return res
         except Exception as e:
-            logger.debug('Cache load failed: %s', e)
+            logger.debug("Cache load failed: %s", e)
+
+        return None
+
+    def _load_multi_day(
+        self,
+        request: contracts.DataRequest,
+    ) -> pd.DataFrame | None:
+        """Load multi-day data from individual day caches.
+
+        Returns concatenated DataFrame only if ALL days are cached.
+        Returns None if any day is missing (triggers full Bloomberg fetch).
+
+        Args:
+            request: Data request with start_datetime and end_datetime.
+
+        Returns:
+            Concatenated DataFrame if all days cached, None otherwise.
+        """
+        from xbbg.utils import pipeline
+
+        day_files = multi_day_bar_files(
+            ticker=request.ticker,
+            start_datetime=request.start_datetime,
+            end_datetime=request.end_datetime,
+            typ=request.event_type,
+        )
+
+        if not day_files:
+            return None
+
+        # Check if all files exist first (fail fast)
+        missing_days = [dt for dt, path in day_files if not files.exists(path)]
+        if missing_days:
+            logger.debug(
+                "Multi-day cache miss: %d of %d days missing for %s (first missing: %s)",
+                len(missing_days),
+                len(day_files),
+                request.ticker,
+                missing_days[:3],
+            )
+            return None
+
+        # All files exist - load and concatenate
+        dfs = []
+        for _dt_str, path in day_files:
+            try:
+                df = pd.read_parquet(path)
+                dfs.append(df)
+            except Exception as e:
+                logger.debug("Failed to load cache file %s: %s", path, e)
+                return None  # Fail entire load if any file is corrupt
+
+        if not dfs:
+            return None
+
+        result = pd.concat(dfs, axis=0).sort_index().pipe(pipeline.add_ticker, ticker=request.ticker)
+
+        # Filter to exact datetime range requested
+        start_ts = pd.Timestamp(request.start_datetime)
+        end_ts = pd.Timestamp(request.end_datetime)
+
+        # Handle timezone: localize filter timestamps to match index timezone
+        if result.index.tz is not None:
+            start_ts = (
+                start_ts.tz_localize(result.index.tz) if start_ts.tz is None else start_ts.tz_convert(result.index.tz)
+            )
+            end_ts = end_ts.tz_localize(result.index.tz) if end_ts.tz is None else end_ts.tz_convert(result.index.tz)
+
+        result = result.loc[start_ts:end_ts]
+
+        if not result.empty:
+            logger.debug(
+                "Multi-day cache hit: loaded %d rows from %d cached days for %s",
+                len(result),
+                len(day_files),
+                request.ticker,
+            )
+            return result
 
         return None
 
@@ -233,7 +344,12 @@ class BarCacheAdapter:
     ) -> None:
         """Save bar data to cache."""
         if data.empty:
-            logger.warning('No data to save for %s / %s', request.ticker, request.to_date_string())
+            logger.warning("No data to save for %s / %s", request.ticker, request.to_date_string())
+            return
+
+        # Handle multi-day requests: split and save each day separately
+        if request.is_multi_day():
+            self._save_multi_day(data, request)
             return
 
         # Get cache root (uses default if BBG_ROOT not set)
@@ -249,6 +365,55 @@ class BarCacheAdapter:
             typ=request.event_type,
             **ctx_kwargs,
         )
+
+    def _save_multi_day(
+        self,
+        data: pd.DataFrame,
+        request: contracts.DataRequest,
+    ) -> None:
+        """Save multi-day data as individual day files.
+
+        Splits the DataFrame by date and saves each day separately,
+        allowing future single-day or multi-day requests to reuse the cache.
+
+        Args:
+            data: DataFrame with DatetimeIndex containing multiple days.
+            request: Original data request.
+        """
+        ctx_kwargs = request.context.to_kwargs() if request.context else {}
+
+        # Get the raw data (remove ticker level if MultiIndex columns)
+        if (
+            isinstance(data.columns, pd.MultiIndex) and request.ticker in data.columns.get_level_values(0)
+        ) or request.ticker in data.columns:
+            raw_data = data[request.ticker]
+        else:
+            raw_data = data
+
+        # Group by date and save each day
+        grouped = raw_data.groupby(raw_data.index.date)
+        saved_count = 0
+
+        for date, day_data in grouped:
+            if day_data.empty:
+                continue
+
+            # Use existing save_intraday which handles market timing checks
+            save_intraday(
+                data=day_data,
+                ticker=request.ticker,
+                dt=date,
+                typ=request.event_type,
+                **ctx_kwargs,
+            )
+            saved_count += 1
+
+        if saved_count > 0:
+            logger.debug(
+                "Saved multi-day data: %d days cached for %s",
+                saved_count,
+                request.ticker,
+            )
 
 
 class TickCacheAdapter:
@@ -275,6 +440,3 @@ class TickCacheAdapter:
 # ============================================================================
 # Cache Lookup
 # ============================================================================
-
-
-

--- a/xbbg/tests/test_intraday_api.py
+++ b/xbbg/tests/test_intraday_api.py
@@ -1,0 +1,32 @@
+import os
+
+import pandas as pd
+
+from xbbg.api import intraday
+from xbbg.core.infra import conn
+from xbbg.io import param
+
+
+def test_bdib_uses_cached_parquet_when_available(monkeypatch):
+    """bdib should load from cached intraday parquet and avoid live Bloomberg calls."""
+    data_root = os.path.join(param.PKG_PATH, "tests", "data")
+    monkeypatch.setenv("BBG_ROOT", data_root)
+
+    def _fail(*args, **kwargs):  # pragma: no cover - defensive
+        raise AssertionError("send_request should not be called when cache file exists")
+
+    monkeypatch.setattr(conn, "send_request", _fail)
+
+    df = intraday.bdib(
+        ticker="AAPL US Equity",
+        dt="2018-11-02",
+        session="allday",
+        typ="TRADE",
+        cache=True,
+        reload=False,
+    )
+
+    assert isinstance(df, pd.DataFrame)
+    assert not df.empty
+    # bdib returns MultiIndex columns with ticker as first level
+    assert "AAPL US Equity" in df.columns.get_level_values(0)


### PR DESCRIPTION
## Summary

- Adds caching support for multi-day intraday bar requests introduced in #148
- Multi-day requests are stored as individual day files, enabling cache reuse between single-day and multi-day requests
- Load requires ALL days to be cached (returns None if any missing, triggering Bloomberg fetch)
- Save splits by date and uses existing `save_intraday()` for each day

## Changes

- `multi_day_bar_files()` - helper to generate cache paths for date ranges
- `BarCacheAdapter._load_multi_day()` - load and concatenate cached days
- `BarCacheAdapter._save_multi_day()` - split and save each day separately
- Updated `load()` and `save()` to route multi-day requests appropriately
- Fixed broken imports in test files (`storage` -> `param`)

## Test plan

- [x] Unit tests pass for existing single-day cache functionality
- [x] Tested multi-day cache load with mock data (concatenates correctly)
- [x] Tested cache miss scenario (returns None when days missing)
- [x] Verified timezone handling for filter timestamps