### PR TITLE
Fix BQL returning only one row for multi-value results

### DIFF
--- a/xbbg/core/process.py
+++ b/xbbg/core/process.py
@@ -657,7 +657,12 @@ def _iter_bql_json_rows(msg: blpapi.Message) -> Iterator[dict]:
                         col_values = sec_col.get('values', [])
                         secondary_cols[col_name] = col_values
 
-                for i, (ticker, value) in enumerate(zip(ids, values, strict=False)):
+                # Iterate over all values; use corresponding ID or last available ID
+                # This handles cases like eco_calendar where one ID maps to many values
+                num_rows = max(len(ids), len(values))
+                for i in range(num_rows):
+                    ticker = ids[i] if i < len(ids) else (ids[-1] if ids else None)
+                    value = values[i] if i < len(values) else None
                     row: dict[str, Any] = {
                         'ID': ticker,
                         field_name: value,
@@ -666,6 +671,15 @@ def _iter_bql_json_rows(msg: blpapi.Message) -> Iterator[dict]:
                         if i < len(col_values):
                             row[col_name] = col_values[i]
                     yield row
+            # rows schema (e.g., eco_calendar, other table-based BQL results)
+            elif 'rows' in field_data and isinstance(field_data['rows'], list):
+                rows_list = field_data['rows']
+                for row_data in rows_list:
+                    if isinstance(row_data, dict):
+                        yield row_data
+                    else:
+                        # If row is not a dict, wrap it
+                        yield {field_name: row_data}
             else:
                 # Fallback: flatten arbitrary dict structure
                 yield dict(_flatten_dict(field_data))

--- a/xbbg/tests/test_bql.py
+++ b/xbbg/tests/test_bql.py
@@ -79,3 +79,75 @@ def test_bql_accepts_params(monkeypatch, fake_handle):
     assert df.iloc[0, 0] == 1
 
 
+def test_iter_bql_json_rows_handles_one_id_many_values():
+    """Test BQL JSON parser handles one ID with many values (e.g., eco_calendar).
+
+    This is the main fix for issue #150: BQL only returns one row when
+    requesting multiple calendar events.
+    """
+    import json
+    from unittest.mock import MagicMock
+
+    import blpapi
+
+    # Simulate eco_calendar response: one ID ("US Country") with multiple values
+    json_payload = json.dumps({
+        "results": {
+            "eco_calendar": {
+                "idColumn": {"values": ["US Country"]},
+                "valuesColumn": {"values": ["GDP", "CPI", "NFP"]},
+                "secondaryColumns": [
+                    {"name": "RELEASE_DATE", "values": ["2024-01-01", "2024-01-15", "2024-01-05"]}
+                ]
+            }
+        }
+    })
+
+    mock_elem = MagicMock()
+    mock_elem.datatype.return_value = blpapi.DataType.STRING
+    mock_elem.getValue.return_value = json_payload
+
+    mock_msg = MagicMock()
+    mock_msg.messageType.return_value = "result"
+    mock_msg.asElement.return_value = mock_elem
+
+    rows = list(process._iter_bql_json_rows(mock_msg))
+
+    # Should return 3 rows (one per value), not 1
+    assert len(rows) == 3
+    assert rows[0] == {"ID": "US Country", "eco_calendar": "GDP", "RELEASE_DATE": "2024-01-01"}
+    assert rows[1] == {"ID": "US Country", "eco_calendar": "CPI", "RELEASE_DATE": "2024-01-15"}
+    assert rows[2] == {"ID": "US Country", "eco_calendar": "NFP", "RELEASE_DATE": "2024-01-05"}
+
+
+def test_iter_bql_json_rows_handles_rows_schema():
+    """Test that BQL JSON parser handles 'rows' schema as fallback."""
+    import json
+    from unittest.mock import MagicMock
+
+    import blpapi
+
+    json_payload = json.dumps({
+        "results": {
+            "data": {
+                "rows": [
+                    {"event_name": "GDP", "country": "US"},
+                    {"event_name": "CPI", "country": "US"},
+                ]
+            }
+        }
+    })
+
+    mock_elem = MagicMock()
+    mock_elem.datatype.return_value = blpapi.DataType.STRING
+    mock_elem.getValue.return_value = json_payload
+
+    mock_msg = MagicMock()
+    mock_msg.messageType.return_value = "result"
+    mock_msg.asElement.return_value = mock_elem
+
+    rows = list(process._iter_bql_json_rows(mock_msg))
+
+    assert len(rows) == 2
+    assert rows[0] == {"event_name": "GDP", "country": "US"}
+    assert rows[1] == {"event_name": "CPI", "country": "US"}


### PR DESCRIPTION
## Summary
- Fixes BQL queries like `eco_calendar` returning only 1 row instead of 50+
- The issue was that `zip(ids, values)` stopped at the shorter list length when `idColumn` has fewer entries than `valuesColumn`
- Now iterates over all values using `max(len(ids), len(values))`

## Test plan
- [x] Verified with authorized-environment query: `blp.bql("get(eco_calendar) for ('US Country')")` now returns 60 rows instead of 1
- [x] Added unit tests for one-ID-many-values scenario
- [x] Added unit tests for 'rows' schema fallback
- [x] Linting passes with ruff

Fixes #150