### PR TITLE
fix: remove pandas version cap to support Python 3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
   "numpy>=2.2.6",
-  "pandas>=2.0,<=2.3.0",
+  "pandas>=2.0",
   "pandas-market-calendars>=5.1.3",
   "pyarrow>=22.0.0",
   "pytest>=8.4.2",


### PR DESCRIPTION
## Summary

Remove upper bound on pandas version (was <=2.3.0) to allow installation of pandas 2.3.3+ which includes pre-built wheels for Python 3.14.

**Before:** `pandas>=2.0,<=2.3.0`
**After:** `pandas>=2.0`

## Changes

- Updated `pyproject.toml` to remove the pandas version cap

## Test Plan

- [x] Verified installation works on Python 3.10, 3.11, 3.12, 3.13, and 3.14 using uv

Closes #159