### PR TITLE
fix: update Japan equity market hours for TSE trading extension

### DIFF
--- a/xbbg/markets/config/exch.yml
+++ b/xbbg/markets/config/exch.yml
@@ -20,11 +20,11 @@ EquityAustralia:
 EquityJapan:
   tz: Asia/Tokyo
   allday: [800, 1545]
-  day: [901, 1458]
+  day: [901, 1525]
   am: [901, 1130]
-  pm: [1230, 1458]
+  pm: [1230, 1525]
   pre: [0800, 901]
-  post: [1459, 1545]
+  post: [1526, 1545]
 
 EquitySouthKorea:
   tz: Asia/Seoul


### PR DESCRIPTION
## Summary

Update EquityJapan session times in exch.yml to reflect Tokyo Stock Exchange trading hour extension effective November 5, 2024.

## Background

The TSE extended trading hours for the first time in 70 years:
- **Zaraba (regular) trading** now ends at 15:25 (was 15:00)
- **New Closing Auction period**: 15:25-15:30 (5-minute auction)
- **Official market close**: 15:30

Reference: https://corporate.quick.co.jp/en/japanmarketsview/equity/one-month-to-extension-of-tokyo-stock-exchange-trading-hours-new-market-close-system-to-be-introduced/

## Changes

| Session | Before | After |
|---------|--------|-------|
| `day` | [901, 1458] | [901, 1525] |
| `pm` | [1230, 1458] | [1230, 1525] |
| `post` | [1459, 1545] | [1526, 1545] |

- `am`, `allday`, `pre` unchanged

## Test Plan

- [x] Verified config loads correctly with `exch_info('EquityJapan')`

Closes #160