### PR TITLE
feat: add yas() function for Bloomberg YAS analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **yas()**: New Bloomberg YAS (Yield Analysis) wrapper for fixed income analytics
+  - Provides convenient interface to Bloomberg's YAS calculator via `bdp()` overrides
+  - `YieldType` enum for yield calculation type (`YTM=1`, `YTC=2`)
+  - Supports settlement date, spread, yield, price, and benchmark overrides
+  - Parameter mapping: `settle_dt` → `SETTLE_DT`, `yield_type` → `YAS_YLD_FLAG`, etc.
+  - Available via `blp.yas()` or `from xbbg.api.fixed_income import yas, YieldType`
 - **Treasury & SOFR futures support**: Added TY, ZN, ZB, ZF, ZT, UB, TN (Treasury), SFR, SR1, SR3 (SOFR), and ED (Eurodollar) futures to assets.yml (#198)
 
 ### Fixed

--- a/xbbg/api/fixed_income/__init__.py
+++ b/xbbg/api/fixed_income/__init__.py
@@ -1,0 +1,9 @@
+"""Bloomberg Fixed Income API.
+
+Provides convenience functions for fixed income analytics including
+yield and spread analysis (YAS).
+"""
+
+from xbbg.api.fixed_income.yas import YieldType, yas
+
+__all__ = ["yas", "YieldType"]

--- a/xbbg/api/fixed_income/yas.py
+++ b/xbbg/api/fixed_income/yas.py
@@ -1,0 +1,157 @@
+"""Bloomberg Yield & Spread Analysis (YAS) API.
+
+Provides convenience functions for fixed income yield and spread calculations.
+"""
+
+from __future__ import annotations
+
+from enum import IntEnum
+import logging
+
+import pandas as pd
+
+from xbbg.backend import Backend, Format
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["yas", "YieldType"]
+
+
+class YieldType(IntEnum):
+    """Bloomberg YAS yield calculation type (YAS_YLD_FLAG override).
+
+    Used to specify whether to calculate Yield to Maturity or Yield to Call.
+
+    Examples:
+        >>> from xbbg.api.fixed_income import YieldType
+        >>> YieldType.YTM
+        <YieldType.YTM: 1>
+        >>> YieldType.YTC
+        <YieldType.YTC: 2>
+        >>> int(YieldType.YTM)
+        1
+    """
+
+    YTM = 1  # Yield to Maturity
+    YTC = 2  # Yield to Call
+
+
+def yas(
+    tickers: str | list[str],
+    flds: str | list[str] = "YAS_BOND_YLD",
+    *,
+    settle_dt: str | pd.Timestamp | None = None,
+    yield_type: YieldType | int | None = None,
+    spread: float | None = None,
+    yield_: float | None = None,
+    price: float | None = None,
+    benchmark: str | None = None,
+    backend: Backend | None = None,
+    format: Format | None = None,
+    **kwargs,
+) -> pd.DataFrame:
+    """Bloomberg Yield & Spread Analysis (YAS) data.
+
+    Convenience wrapper for YAS fields with commonly-used overrides as named parameters.
+    Replicates Bloomberg YAS<GO> screen functionality via API.
+
+    Args:
+        tickers: Bond ticker(s) (e.g., 'US912810TD00 Govt', '/isin/US912810TD00')
+        flds: YAS field(s) to retrieve. Defaults to 'YAS_BOND_YLD'.
+            Common fields: YAS_BOND_YLD, YAS_BOND_PX, YAS_MOD_DUR,
+            YAS_OAS_SPREAD, YAS_ASW_SPREAD, YAS_Z_SPREAD, YAS_YLD_SPREAD
+        settle_dt: Settlement date for yield calculation (YYYYMMDD or datetime).
+            Maps to SETTLE_DT override.
+        yield_type: Yield calculation type - YieldType.YTM (1) or YieldType.YTC (2).
+            Maps to YAS_YLD_FLAG override.
+        spread: Spread to benchmark in basis points.
+            Maps to YAS_YLD_SPREAD override.
+        yield_: Input yield to calculate price from.
+            Maps to YAS_BOND_YLD override.
+        price: Input price to calculate yield from.
+            Maps to YAS_BOND_PX override.
+        benchmark: Benchmark bond ticker for spread calculations.
+            Maps to YAS_BNCHMRK_BOND override.
+        backend: Output backend (e.g., Backend.PANDAS, Backend.POLARS).
+            Defaults to global setting.
+        format: Output format (e.g., Format.WIDE, Format.LONG).
+            Defaults to global setting.
+        **kwargs: Additional Bloomberg overrides passed directly to bdp().
+
+    Returns:
+        pd.DataFrame: YAS data with tickers as index and fields as columns.
+
+    Examples:
+        Basic usage (requires Bloomberg session; skipped in doctest):
+
+        >>> from xbbg import blp  # doctest: +SKIP
+        >>> from xbbg.api.fixed_income import YieldType  # doctest: +SKIP
+        >>>
+        >>> # Get yield to maturity for a bond
+        >>> blp.yas('US912810TD00 Govt')  # doctest: +SKIP
+        >>>
+        >>> # Get yield with custom settlement date
+        >>> blp.yas('US912810TD00 Govt', settle_dt='20240115')  # doctest: +SKIP
+        >>>
+        >>> # Get yield to call instead of yield to maturity
+        >>> blp.yas('XYZ Corp', yield_type=YieldType.YTC)  # doctest: +SKIP
+        >>>
+        >>> # Calculate yield from a given price
+        >>> blp.yas('US912810TD00 Govt', price=98.5)  # doctest: +SKIP
+        >>>
+        >>> # Calculate price from a given yield
+        >>> blp.yas('US912810TD00 Govt', flds='YAS_BOND_PX', yield_=4.5)  # doctest: +SKIP
+        >>>
+        >>> # Get spread to a specific benchmark
+        >>> blp.yas('XYZ Corp', flds='YAS_YLD_SPREAD', benchmark='US912810TD00 Govt')  # doctest: +SKIP
+        >>>
+        >>> # Get multiple YAS analytics
+        >>> blp.yas('US912810TD00 Govt', ['YAS_BOND_YLD', 'YAS_MOD_DUR', 'YAS_Z_SPREAD'])  # doctest: +SKIP
+    """
+    from xbbg.api.reference import bdp
+
+    # Build overrides dict from named parameters
+    overrides: dict[str, object] = {}
+
+    if settle_dt is not None:
+        # Convert to YYYYMMDD format if needed
+        formatted_dt: str | None = None
+
+        if isinstance(settle_dt, str):
+            # Try to parse and reformat to ensure consistent format
+            try:
+                dt = pd.Timestamp(settle_dt)
+                if dt is not pd.NaT:
+                    formatted_dt = f"{dt.year:04d}{dt.month:02d}{dt.day:02d}"
+            except (ValueError, TypeError):
+                # If parsing fails, pass through as-is
+                formatted_dt = settle_dt
+        elif isinstance(settle_dt, pd.Timestamp) and settle_dt is not pd.NaT:
+            formatted_dt = f"{settle_dt.year:04d}{settle_dt.month:02d}{settle_dt.day:02d}"
+        else:
+            formatted_dt = str(settle_dt) if settle_dt is not None else None
+
+        if formatted_dt is not None:
+            overrides["SETTLE_DT"] = formatted_dt
+
+    if yield_type is not None:
+        # Accept both YieldType enum and raw int
+        overrides["YAS_YLD_FLAG"] = int(yield_type)
+
+    if spread is not None:
+        overrides["YAS_YLD_SPREAD"] = spread
+
+    if yield_ is not None:
+        overrides["YAS_BOND_YLD"] = yield_
+
+    if price is not None:
+        overrides["YAS_BOND_PX"] = price
+
+    if benchmark is not None:
+        overrides["YAS_BNCHMRK_BOND"] = benchmark
+
+    # Merge with any additional kwargs overrides (kwargs take precedence)
+    overrides.update(kwargs)
+
+    # Call bdp with the YAS fields and overrides
+    return bdp(tickers=tickers, flds=flds, backend=backend, format=format, **overrides)

--- a/xbbg/blp.py
+++ b/xbbg/blp.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import logging
 
 from xbbg import __version__
+from xbbg.api.fixed_income import yas as _yas
 
 # Import implementations with underscore prefix for wrapping
 from xbbg.api.helpers import adjust_ccy as _adjust_ccy
@@ -63,6 +64,7 @@ from xbbg.deprecation import (
     warn_refresh_studies,
     warn_subscribe,
     warn_turnover,
+    warn_yas,
 )
 from xbbg.markets import resolvers as _res
 
@@ -228,6 +230,15 @@ def corporate_bonds(*args, **kwargs):
     return _corporate_bonds(*args, **kwargs)
 
 
+def yas(*args, **kwargs):
+    """DEPRECATED: Bloomberg Yield & Spread Analysis (YAS) data.
+
+    In v1.0, moved to xbbg.ext.yas().
+    """
+    warn_yas()
+    return _yas(*args, **kwargs)
+
+
 # Resolver functions - moved to xbbg.ext
 
 
@@ -326,6 +337,7 @@ __all__ = [
     "etf_holdings",
     "preferreds",
     "corporate_bonds",
+    "yas",
     "fut_ticker",
     "active_futures",
     "cdx_ticker",

--- a/xbbg/deprecation.py
+++ b/xbbg/deprecation.py
@@ -296,3 +296,8 @@ def warn_preferreds() -> None:
 def warn_corporate_bonds() -> None:
     """Warn about corporate_bonds() move to ext module."""
     warn_function_moved("corporate_bonds", "xbbg.ext.corporate_bonds")
+
+
+def warn_yas() -> None:
+    """Warn about yas() move to ext module."""
+    warn_function_moved("yas", "xbbg.ext.yas")

--- a/xbbg/tests/test_yas.py
+++ b/xbbg/tests/test_yas.py
@@ -1,0 +1,246 @@
+"""Tests for Bloomberg YAS (Yield & Spread Analysis) API."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+
+from xbbg.api.fixed_income import YieldType, yas
+
+
+class TestYieldTypeEnum:
+    """Tests for YieldType enum."""
+
+    def test_yield_type_ytm_value(self):
+        """Test YTM enum value is 1."""
+        assert YieldType.YTM == 1
+        assert int(YieldType.YTM) == 1
+
+    def test_yield_type_ytc_value(self):
+        """Test YTC enum value is 2."""
+        assert YieldType.YTC == 2
+        assert int(YieldType.YTC) == 2
+
+    def test_yield_type_is_int_enum(self):
+        """Test YieldType is an IntEnum and can be used as int."""
+        assert isinstance(YieldType.YTM, int)
+        assert isinstance(YieldType.YTC, int)
+
+    def test_yield_type_comparison(self):
+        """Test YieldType can be compared with integers."""
+        assert YieldType.YTM == 1
+        assert YieldType.YTC == 2
+        assert YieldType.YTM < YieldType.YTC
+
+
+class TestYasOverrideMapping:
+    """Tests for YAS override parameter mapping."""
+
+    @patch("xbbg.api.reference.bdp")
+    def test_yas_default_field(self, mock_bdp: MagicMock):
+        """Test default field is YAS_BOND_YLD."""
+        mock_bdp.return_value = pd.DataFrame()
+        yas("US912810TD00 Govt")
+        mock_bdp.assert_called_once()
+        call_kwargs = mock_bdp.call_args
+        assert call_kwargs[1]["flds"] == "YAS_BOND_YLD"
+
+    @patch("xbbg.api.reference.bdp")
+    def test_yas_custom_fields(self, mock_bdp: MagicMock):
+        """Test custom fields are passed through."""
+        mock_bdp.return_value = pd.DataFrame()
+        yas("US912810TD00 Govt", flds=["YAS_BOND_YLD", "YAS_MOD_DUR"])
+        mock_bdp.assert_called_once()
+        call_kwargs = mock_bdp.call_args
+        assert call_kwargs[1]["flds"] == ["YAS_BOND_YLD", "YAS_MOD_DUR"]
+
+    @patch("xbbg.api.reference.bdp")
+    def test_yas_settle_dt_string(self, mock_bdp: MagicMock):
+        """Test settle_dt string override mapping."""
+        mock_bdp.return_value = pd.DataFrame()
+        yas("US912810TD00 Govt", settle_dt="20240115")
+        mock_bdp.assert_called_once()
+        call_kwargs = mock_bdp.call_args
+        assert call_kwargs[1]["SETTLE_DT"] == "20240115"
+
+    @patch("xbbg.api.reference.bdp")
+    def test_yas_settle_dt_timestamp(self, mock_bdp: MagicMock):
+        """Test settle_dt Timestamp override mapping."""
+        mock_bdp.return_value = pd.DataFrame()
+        yas("US912810TD00 Govt", settle_dt=pd.Timestamp("2024-01-15"))
+        mock_bdp.assert_called_once()
+        call_kwargs = mock_bdp.call_args
+        assert call_kwargs[1]["SETTLE_DT"] == "20240115"
+
+    @patch("xbbg.api.reference.bdp")
+    def test_yas_settle_dt_date_string_format(self, mock_bdp: MagicMock):
+        """Test settle_dt with various date string formats."""
+        mock_bdp.return_value = pd.DataFrame()
+        yas("US912810TD00 Govt", settle_dt="2024-01-15")
+        mock_bdp.assert_called_once()
+        call_kwargs = mock_bdp.call_args
+        assert call_kwargs[1]["SETTLE_DT"] == "20240115"
+
+    @patch("xbbg.api.reference.bdp")
+    def test_yas_yield_type_ytm(self, mock_bdp: MagicMock):
+        """Test yield_type YTM override mapping."""
+        mock_bdp.return_value = pd.DataFrame()
+        yas("US912810TD00 Govt", yield_type=YieldType.YTM)
+        mock_bdp.assert_called_once()
+        call_kwargs = mock_bdp.call_args
+        assert call_kwargs[1]["YAS_YLD_FLAG"] == 1
+
+    @patch("xbbg.api.reference.bdp")
+    def test_yas_yield_type_ytc(self, mock_bdp: MagicMock):
+        """Test yield_type YTC override mapping."""
+        mock_bdp.return_value = pd.DataFrame()
+        yas("US912810TD00 Govt", yield_type=YieldType.YTC)
+        mock_bdp.assert_called_once()
+        call_kwargs = mock_bdp.call_args
+        assert call_kwargs[1]["YAS_YLD_FLAG"] == 2
+
+    @patch("xbbg.api.reference.bdp")
+    def test_yas_yield_type_int(self, mock_bdp: MagicMock):
+        """Test yield_type accepts raw integer."""
+        mock_bdp.return_value = pd.DataFrame()
+        yas("US912810TD00 Govt", yield_type=1)
+        mock_bdp.assert_called_once()
+        call_kwargs = mock_bdp.call_args
+        assert call_kwargs[1]["YAS_YLD_FLAG"] == 1
+
+    @patch("xbbg.api.reference.bdp")
+    def test_yas_spread_override(self, mock_bdp: MagicMock):
+        """Test spread override mapping."""
+        mock_bdp.return_value = pd.DataFrame()
+        yas("US912810TD00 Govt", spread=75.5)
+        mock_bdp.assert_called_once()
+        call_kwargs = mock_bdp.call_args
+        assert call_kwargs[1]["YAS_YLD_SPREAD"] == 75.5
+
+    @patch("xbbg.api.reference.bdp")
+    def test_yas_yield_override(self, mock_bdp: MagicMock):
+        """Test yield_ override mapping."""
+        mock_bdp.return_value = pd.DataFrame()
+        yas("US912810TD00 Govt", yield_=4.5)
+        mock_bdp.assert_called_once()
+        call_kwargs = mock_bdp.call_args
+        assert call_kwargs[1]["YAS_BOND_YLD"] == 4.5
+
+    @patch("xbbg.api.reference.bdp")
+    def test_yas_price_override(self, mock_bdp: MagicMock):
+        """Test price override mapping."""
+        mock_bdp.return_value = pd.DataFrame()
+        yas("US912810TD00 Govt", price=98.5)
+        mock_bdp.assert_called_once()
+        call_kwargs = mock_bdp.call_args
+        assert call_kwargs[1]["YAS_BOND_PX"] == 98.5
+
+    @patch("xbbg.api.reference.bdp")
+    def test_yas_benchmark_override(self, mock_bdp: MagicMock):
+        """Test benchmark override mapping."""
+        mock_bdp.return_value = pd.DataFrame()
+        yas("XYZ Corp", benchmark="US912810TD00 Govt")
+        mock_bdp.assert_called_once()
+        call_kwargs = mock_bdp.call_args
+        assert call_kwargs[1]["YAS_BNCHMRK_BOND"] == "US912810TD00 Govt"
+
+    @patch("xbbg.api.reference.bdp")
+    def test_yas_multiple_overrides(self, mock_bdp: MagicMock):
+        """Test multiple overrides are combined correctly."""
+        mock_bdp.return_value = pd.DataFrame()
+        yas(
+            "US912810TD00 Govt",
+            settle_dt="20240115",
+            yield_type=YieldType.YTM,
+            price=98.5,
+        )
+        mock_bdp.assert_called_once()
+        call_kwargs = mock_bdp.call_args
+        assert call_kwargs[1]["SETTLE_DT"] == "20240115"
+        assert call_kwargs[1]["YAS_YLD_FLAG"] == 1
+        assert call_kwargs[1]["YAS_BOND_PX"] == 98.5
+
+    @patch("xbbg.api.reference.bdp")
+    def test_yas_kwargs_passthrough(self, mock_bdp: MagicMock):
+        """Test additional kwargs are passed through."""
+        mock_bdp.return_value = pd.DataFrame()
+        yas("US912810TD00 Govt", CUSTOM_OVERRIDE="value")
+        mock_bdp.assert_called_once()
+        call_kwargs = mock_bdp.call_args
+        assert call_kwargs[1]["CUSTOM_OVERRIDE"] == "value"
+
+    @patch("xbbg.api.reference.bdp")
+    def test_yas_kwargs_override_named_params(self, mock_bdp: MagicMock):
+        """Test kwargs override named parameters (kwargs take precedence)."""
+        mock_bdp.return_value = pd.DataFrame()
+        # YAS_BOND_PX in kwargs should override price parameter
+        yas("US912810TD00 Govt", price=98.5, YAS_BOND_PX=99.0)
+        mock_bdp.assert_called_once()
+        call_kwargs = mock_bdp.call_args
+        # kwargs value should win
+        assert call_kwargs[1]["YAS_BOND_PX"] == 99.0
+
+    @patch("xbbg.api.reference.bdp")
+    def test_yas_no_overrides_when_none(self, mock_bdp: MagicMock):
+        """Test no overrides added when parameters are None."""
+        mock_bdp.return_value = pd.DataFrame()
+        yas("US912810TD00 Govt")
+        mock_bdp.assert_called_once()
+        call_kwargs = mock_bdp.call_args
+        # Should not have any YAS override keys
+        assert "SETTLE_DT" not in call_kwargs[1]
+        assert "YAS_YLD_FLAG" not in call_kwargs[1]
+        assert "YAS_YLD_SPREAD" not in call_kwargs[1]
+        assert "YAS_BOND_YLD" not in call_kwargs[1]
+        assert "YAS_BOND_PX" not in call_kwargs[1]
+        assert "YAS_BNCHMRK_BOND" not in call_kwargs[1]
+
+
+class TestYasBackendFormat:
+    """Tests for backend and format parameter passthrough."""
+
+    @patch("xbbg.api.reference.bdp")
+    def test_yas_backend_passthrough(self, mock_bdp: MagicMock):
+        """Test backend parameter is passed through."""
+        from xbbg.backend import Backend
+
+        mock_bdp.return_value = pd.DataFrame()
+        yas("US912810TD00 Govt", backend=Backend.PANDAS)
+        mock_bdp.assert_called_once()
+        call_kwargs = mock_bdp.call_args
+        assert call_kwargs[1]["backend"] == Backend.PANDAS
+
+    @patch("xbbg.api.reference.bdp")
+    def test_yas_format_passthrough(self, mock_bdp: MagicMock):
+        """Test format parameter is passed through."""
+        from xbbg.backend import Format
+
+        mock_bdp.return_value = pd.DataFrame()
+        yas("US912810TD00 Govt", format=Format.LONG)
+        mock_bdp.assert_called_once()
+        call_kwargs = mock_bdp.call_args
+        assert call_kwargs[1]["format"] == Format.LONG
+
+
+class TestYasImports:
+    """Tests for module imports."""
+
+    def test_import_from_fixed_income(self):
+        """Test importing from xbbg.api.fixed_income."""
+        from xbbg.api.fixed_income import YieldType, yas
+
+        assert callable(yas)
+        assert YieldType.YTM == 1
+
+    def test_import_from_blp(self):
+        """Test importing from xbbg.blp (with deprecation warning)."""
+        import warnings
+
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            from xbbg import blp
+
+            # Access yas to trigger import
+            assert hasattr(blp, "yas")
+            assert callable(blp.yas)


### PR DESCRIPTION
## Summary

Add Bloomberg Yield & Spread Analysis (YAS) wrapper function for fixed income analytics.

- New `yas()` function providing convenient interface to Bloomberg's YAS calculator
- `YieldType` enum for yield calculation type (`YTM=1`, `YTC=2`)
- Named parameters for common YAS overrides mapped to Bloomberg fields

## Features

| Parameter | Bloomberg Override | Description |
|-----------|-------------------|-------------|
| `settle_dt` | `SETTLE_DT` | Settlement date for yield calculation |
| `yield_type` | `YAS_YLD_FLAG` | YTM (1) or YTC (2) |
| `spread` | `YAS_YLD_SPREAD` | Spread to benchmark in bps |
| `yield_` | `YAS_BOND_YLD` | Input yield to calculate price |
| `price` | `YAS_BOND_PX` | Input price to calculate yield |
| `benchmark` | `YAS_BNCHMRK_BOND` | Benchmark bond ticker |

## Usage

```python
from xbbg import blp
from xbbg.api.fixed_income import YieldType

# Basic yield query
blp.yas('T 4.5 05/15/38 Govt')

# With settlement date
blp.yas('T 4.5 05/15/38 Govt', settle_dt='20250124')

# Yield to call (for callable bonds)
blp.yas('AAPL 2.65 05/11/50 Corp', yield_type=YieldType.YTC)

# Calculate yield from price
blp.yas('T 4.5 05/15/38 Govt', price=95.0)

# Calculate price from yield
blp.yas('T 4.5 05/15/38 Govt', flds='YAS_BOND_PX', yield_=4.8)

# Multiple YAS fields
blp.yas('T 4.5 05/15/38 Govt', ['YAS_BOND_YLD', 'YAS_MOD_DUR', 'YAS_ASW_SPREAD'])
```

## Files Changed

- `xbbg/api/fixed_income/__init__.py` - new module exports
- `xbbg/api/fixed_income/yas.py` - implementation
- `xbbg/tests/test_yas.py` - 24 unit tests
- `xbbg/blp.py` - export with deprecation wrapper
- `xbbg/deprecation.py` - `warn_yas()` function
- `CHANGELOG.md` - feature documentation

## Testing

- ✅ 24 unit tests passing
- ✅ authorized-environment tests verified (YTM, YTC, price/yield calculations, settlement date override)