### PR TITLE
fix: handle mixed Python types in Arrow-first BDP pipeline

### DIFF
--- a/xbbg/core/pipeline_core.py
+++ b/xbbg/core/pipeline_core.py
@@ -24,6 +24,65 @@ from xbbg.core.infra import conn
 logger = logging.getLogger(__name__)
 
 
+def _events_to_table(events: list[dict[str, Any]]) -> pa.Table | None:
+    """Convert Bloomberg event dicts directly to a PyArrow Table (no pandas).
+
+    Bloomberg's ``process_*`` functions yield ``dict[str, Any]`` where values
+    come from ``blpapi.Element.getValue()`` — native Python types that vary
+    by field (``float`` for Double fields, ``str`` for String fields,
+    ``datetime`` for Date fields, etc.).  When multiple fields are requested,
+    the ``value`` column becomes a true **variant column** with mixed Python
+    types in the same list.
+
+    ``pa.Table.from_pylist()`` and ``pa.Table.from_pandas()`` both choke on
+    this because Arrow columns are strongly typed.  Instead, we build the
+    table directly: collect all column names from the events, then for each
+    column attempt ``pa.array()`` with type inference.  If inference fails
+    (mixed types), stringify all values in that column to ``pa.string()``,
+    preserving ``None`` as Arrow null.
+
+    Args:
+        events: List of dicts from Bloomberg process functions.
+
+    Returns:
+        PyArrow Table, or None if events is empty.
+    """
+    if not events:
+        return None
+
+    # Collect column names in insertion order (first event defines order,
+    # later events may add columns — e.g. BDS array fields)
+    col_names: list[str] = []
+    seen: set[str] = set()
+    for evt in events:
+        for key in evt:
+            if key not in seen:
+                col_names.append(key)
+                seen.add(key)
+
+    # Build one Arrow array per column
+    arrays: list[pa.Array] = []
+    for col in col_names:
+        values = [evt.get(col) for evt in events]
+
+        # Fast path: let Arrow infer the type
+        try:
+            arrays.append(pa.array(values, from_pandas=True))
+            continue
+        except (pa.ArrowInvalid, pa.ArrowTypeError, pa.ArrowNotImplementedError):
+            pass
+
+        # Slow path: stringify non-None values → pa.string()
+        arrays.append(
+            pa.array(
+                [None if v is None else str(v) for v in values],
+                type=pa.string(),
+            )
+        )
+
+    return pa.table(dict(zip(col_names, arrays, strict=True)))
+
+
 class RequestBuilderStrategy(Protocol):
     """Strategy for building Bloomberg requests."""
 
@@ -260,7 +319,18 @@ class BloombergPipeline(BaseContextAware):
             warn_defaults_changing()
 
         # Get Arrow table from transformed data (fallback for pandas during transition)
-        arrow_table = transformed if isinstance(transformed, pa.Table) else pa.Table.from_pandas(transformed)
+        if isinstance(transformed, pa.Table):
+            arrow_table = transformed
+        else:
+            try:
+                arrow_table = pa.Table.from_pandas(transformed)
+            except (pa.ArrowInvalid, pa.ArrowTypeError):
+                # Mixed-type columns — coerce object columns to string
+                transformed = transformed.copy()
+                for col in transformed.columns:
+                    if transformed[col].dtype == object:
+                        transformed[col] = transformed[col].astype("string")
+                arrow_table = pa.Table.from_pandas(transformed)
 
         result = to_output(
             arrow_table,
@@ -402,26 +472,8 @@ class BloombergPipeline(BaseContextAware):
 
     @staticmethod
     def _events_to_arrow(events: list[dict]) -> pa.Table | None:
-        """Convert event dicts to Arrow table."""
-        if not events:
-            return None
-
-        # Build DataFrame from events - let pandas infer types naturally
-        df = pd.DataFrame(events)
-
-        # Handle mixed-type 'value' column (can contain strings, floats, dates)
-        # Convert to string only if it has mixed types that PyArrow can't handle
-        if "value" in df.columns and df["value"].dtype == object:
-            # Check if all non-null values are numeric
-            try:
-                pd.to_numeric(df["value"], errors="raise")
-            except (ValueError, TypeError):
-                # Mixed types - convert to string for Arrow compatibility
-                df["value"] = df["value"].astype(str)
-
-        # Convert to Arrow table, letting PyArrow infer types from pandas
-        # This preserves numeric types (float64, int64) and handles dates properly
-        return pa.Table.from_pandas(df, preserve_index=False)
+        """Convert event dicts to Arrow table (no pandas intermediary)."""
+        return _events_to_table(events)
 
     def _persist_cache(
         self,

--- a/xbbg/tests/test_events_to_table.py
+++ b/xbbg/tests/test_events_to_table.py
@@ -1,0 +1,220 @@
+"""Regression tests for _events_to_table (mixed-type Arrow conversion).
+
+Bloomberg's process_* functions yield event dicts where the ``value`` column
+is a true variant — it can contain float, str, datetime, bool, and None in
+the same list.  ``pa.Table.from_pandas()`` and ``pa.Table.from_pylist()``
+both raise ``ArrowInvalid`` on such mixed-type columns.
+
+``_events_to_table`` builds Arrow tables directly from event dicts, falling
+back to ``pa.string()`` for columns whose types cannot be inferred uniformly.
+
+Regression: https://github.com/alpha-xone/xbbg/issues/XXX
+  bdp(['ES1 Index'], ['FUT_CONT_SIZE', 'FUT_VAL_PT']) raised ArrowInvalid
+  because FUT_CONT_SIZE returns float (Double) while FUT_VAL_PT returns str
+  (String), creating a mixed float+str ``value`` column.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+
+import pyarrow as pa
+
+from xbbg.core.pipeline_core import _events_to_table
+
+# ---------------------------------------------------------------------------
+# Basic contract
+# ---------------------------------------------------------------------------
+
+
+class TestEventsToTableBasic:
+    """Core behavior: empty input, uniform types."""
+
+    def test_empty_events_returns_none(self):
+        assert _events_to_table([]) is None
+
+    def test_single_event(self):
+        events = [{"ticker": "X", "field": "PX_LAST", "value": 100.0}]
+        table = _events_to_table(events)
+        assert isinstance(table, pa.Table)
+        assert table.num_rows == 1
+        assert table.num_columns == 3
+
+    def test_uniform_float_values(self):
+        events = [
+            {"ticker": "X", "field": "PX_LAST", "value": 100.0},
+            {"ticker": "X", "field": "VOLUME", "value": 5000.0},
+        ]
+        table = _events_to_table(events)
+        assert table.num_rows == 2
+        # All-float value column should stay numeric (double)
+        assert pa.types.is_floating(table.column("value").type)
+
+    def test_uniform_string_values(self):
+        events = [
+            {"ticker": "X", "field": "NAME", "value": "Foo Corp"},
+            {"ticker": "X", "field": "SECTOR", "value": "Tech"},
+        ]
+        table = _events_to_table(events)
+        assert pa.types.is_string(table.column("value").type) or pa.types.is_large_string(table.column("value").type)
+
+
+# ---------------------------------------------------------------------------
+# The actual bug: mixed-type value column
+# ---------------------------------------------------------------------------
+
+
+class TestMixedTypeValueColumn:
+    """Regression tests for the ArrowInvalid bug on mixed-type value columns."""
+
+    def test_float_and_string_values(self):
+        """The exact scenario that triggered the bug:
+        FUT_CONT_SIZE=50.0 (float) + FUT_VAL_PT='50.00' (str).
+        """
+        events = [
+            {"ticker": "ES1 Index", "field": "FUT_CONT_SIZE", "value": 50.0},
+            {"ticker": "ES1 Index", "field": "FUT_VAL_PT", "value": "50.00"},
+        ]
+        table = _events_to_table(events)
+        assert table is not None
+        assert table.num_rows == 2
+        # Mixed column falls back to string
+        assert pa.types.is_string(table.column("value").type) or pa.types.is_large_string(table.column("value").type)
+        # Values are preserved (as strings)
+        values = table.column("value").to_pylist()
+        assert "50.0" in values
+        assert "50.00" in values
+
+    def test_float_string_and_name(self):
+        """Multi-ticker, multi-field: numeric + string-typed + text fields."""
+        events = [
+            {"ticker": "ES1 Index", "field": "FUT_CONT_SIZE", "value": 50.0},
+            {"ticker": "ES1 Index", "field": "FUT_VAL_PT", "value": "50.00"},
+            {"ticker": "ES1 Index", "field": "SECURITY_NAME", "value": "Generic 1st 'ES' Future"},
+        ]
+        table = _events_to_table(events)
+        assert table is not None
+        assert table.num_rows == 3
+
+    def test_int_and_string_values(self):
+        events = [
+            {"ticker": "X", "field": "A", "value": 42},
+            {"ticker": "X", "field": "B", "value": "hello"},
+        ]
+        table = _events_to_table(events)
+        assert table is not None
+        assert table.num_rows == 2
+
+    def test_float_and_date_values(self):
+        events = [
+            {"ticker": "X", "field": "PX_LAST", "value": 100.0},
+            {"ticker": "X", "field": "MATURITY", "value": date(2030, 1, 15)},
+        ]
+        table = _events_to_table(events)
+        assert table is not None
+        assert table.num_rows == 2
+
+    def test_float_string_date_bool_mixed(self):
+        """Kitchen sink: every type Bloomberg might return."""
+        events = [
+            {"ticker": "X", "field": "PRICE", "value": 99.5},
+            {"ticker": "X", "field": "NAME", "value": "Acme"},
+            {"ticker": "X", "field": "MATURITY", "value": date(2030, 6, 15)},
+            {"ticker": "X", "field": "IS_CALLABLE", "value": True},
+            {"ticker": "X", "field": "COUPON_DT", "value": datetime(2025, 3, 1, 12, 0)},
+        ]
+        table = _events_to_table(events)
+        assert table is not None
+        assert table.num_rows == 5
+
+
+# ---------------------------------------------------------------------------
+# Null / missing value handling
+# ---------------------------------------------------------------------------
+
+
+class TestNullHandling:
+    """Ensure None and NaN are preserved as Arrow nulls, not stringified."""
+
+    def test_none_in_uniform_column(self):
+        events = [
+            {"ticker": "X", "field": "A", "value": 1.0},
+            {"ticker": "X", "field": "B", "value": None},
+            {"ticker": "X", "field": "C", "value": 3.0},
+        ]
+        table = _events_to_table(events)
+        assert table.column("value")[1].as_py() is None
+
+    def test_none_in_mixed_column(self):
+        events = [
+            {"ticker": "X", "field": "A", "value": 1.0},
+            {"ticker": "X", "field": "B", "value": None},
+            {"ticker": "X", "field": "C", "value": "text"},
+        ]
+        table = _events_to_table(events)
+        assert table.column("value")[1].as_py() is None
+
+    def test_nan_in_uniform_float_column(self):
+        events = [
+            {"ticker": "X", "field": "A", "value": 1.0},
+            {"ticker": "X", "field": "B", "value": float("nan")},
+        ]
+        table = _events_to_table(events)
+        # NaN should be preserved as null in Arrow
+        assert table.column("value")[1].as_py() is None
+
+
+# ---------------------------------------------------------------------------
+# Non-uniform dict keys (BDS array fields add extra columns)
+# ---------------------------------------------------------------------------
+
+
+class TestNonUniformKeys:
+    """Events with different sets of keys (e.g. BDS array expansion)."""
+
+    def test_extra_key_in_later_event(self):
+        events = [
+            {"ticker": "X", "field": "A", "value": 1.0},
+            {"ticker": "X", "field": "B", "value": "hello", "extra": "col"},
+        ]
+        table = _events_to_table(events)
+        assert table.num_columns == 4
+        assert "extra" in table.column_names
+        # First row has no "extra" → should be null
+        assert table.column("extra")[0].as_py() is None
+        assert table.column("extra")[1].as_py() == "col"
+
+    def test_column_order_preserves_first_event(self):
+        events = [
+            {"ticker": "X", "field": "Z"},
+            {"ticker": "Y", "alpha": 1},
+        ]
+        table = _events_to_table(events)
+        # Column order should follow insertion order from events
+        assert table.column_names[0] == "ticker"
+        assert table.column_names[1] == "field"
+
+
+# ---------------------------------------------------------------------------
+# Integration: BloombergPipeline._events_to_arrow delegates correctly
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineEventsToArrow:
+    """Verify the pipeline static method delegates to _events_to_table."""
+
+    def test_events_to_arrow_returns_none_for_empty(self):
+        from xbbg.core.pipeline_core import BloombergPipeline
+
+        assert BloombergPipeline._events_to_arrow([]) is None
+
+    def test_events_to_arrow_mixed_types(self):
+        from xbbg.core.pipeline_core import BloombergPipeline
+
+        events = [
+            {"ticker": "ES1 Index", "field": "FUT_CONT_SIZE", "value": 50.0},
+            {"ticker": "ES1 Index", "field": "FUT_VAL_PT", "value": "50.00"},
+        ]
+        table = BloombergPipeline._events_to_arrow(events)
+        assert isinstance(table, pa.Table)
+        assert table.num_rows == 2

--- a/xbbg/tests/test_live_endpoints.py
+++ b/xbbg/tests/test_live_endpoints.py
@@ -1487,6 +1487,81 @@ def test_stream_survey_field_issue_199():
     print("✓ stream() field values working correctly")
 
 
+@pytest.mark.live_endpoint
+def test_bdp_mixed_type_fields():
+    """Test BDP with fields that return mixed Python types (regression for ArrowInvalid bug).
+
+    Bloomberg returns different Python types for different fields:
+    - FUT_CONT_SIZE → Double → float (e.g., 50.0)
+    - FUT_VAL_PT   → String → str   (e.g., '50.00')
+
+    Before the fix, pa.array([50.0, '50.00']) raised:
+        pyarrow.lib.ArrowInvalid: Could not convert '50.00' with type str:
+        tried to convert to double
+
+    This test verifies the _events_to_table() fix handles mixed types gracefully.
+    """
+    print(f"\n{'=' * 80}")
+    print("Testing BDP (Mixed Type Fields - ArrowInvalid regression)")
+    print(f"{'=' * 80}")
+
+    # The exact call that triggered the original bug
+    result = blp.bdp(
+        tickers=["ES1 Index"],
+        flds=["FUT_CONT_SIZE", "FUT_VAL_PT"],
+    )
+
+    assert isinstance(result, pd.DataFrame), "BDP should return a DataFrame"
+    assert not result.empty, "BDP result should not be empty"
+
+    # Verify both fields are present as columns
+    result_cols_lower = [col.lower() for col in result.columns]
+    assert any("fut_cont_size" in c for c in result_cols_lower), "FUT_CONT_SIZE should be present"
+    assert any("fut_val_pt" in c for c in result_cols_lower), "FUT_VAL_PT should be present"
+
+    print("\nBDP Result (Mixed Types):")
+    print(result)
+    print(f"\nShape: {result.shape}")
+    print(f"Columns: {list(result.columns)}")
+    print(f"Dtypes:\n{result.dtypes}")
+    print("✓ BDP mixed-type fields working correctly (ArrowInvalid bug fixed)")
+
+
+@pytest.mark.live_endpoint
+def test_bdp_mixed_type_multiple_tickers():
+    """Test BDP with mixed-type fields across multiple tickers.
+
+    Extends the ArrowInvalid regression test with multiple tickers to ensure
+    the fix works for multi-row results where each row has mixed types.
+    """
+    print(f"\n{'=' * 80}")
+    print("Testing BDP (Mixed Type Fields - Multiple Tickers)")
+    print(f"{'=' * 80}")
+
+    result = blp.bdp(
+        tickers=["ES1 Index", "NQ1 Index"],
+        flds=["FUT_CONT_SIZE", "FUT_VAL_PT"],
+    )
+
+    assert isinstance(result, pd.DataFrame), "BDP should return a DataFrame"
+    assert not result.empty, "BDP result should not be empty"
+
+    # Verify both tickers present
+    assert len(result) >= 2, "Should have at least 2 rows (one per ticker)"
+
+    # Verify both fields are present as columns
+    result_cols_lower = [col.lower() for col in result.columns]
+    assert any("fut_cont_size" in c for c in result_cols_lower), "FUT_CONT_SIZE should be present"
+    assert any("fut_val_pt" in c for c in result_cols_lower), "FUT_VAL_PT should be present"
+
+    print("\nBDP Result (Mixed Types, Multiple Tickers):")
+    print(result)
+    print(f"\nShape: {result.shape}")
+    print(f"Columns: {list(result.columns)}")
+    print(f"Dtypes:\n{result.dtypes}")
+    print("✓ BDP mixed-type fields with multiple tickers working correctly")
+
+
 if __name__ == "__main__":
     # Allow running tests directly with verbose output
     print("\n" + "=" * 80)


### PR DESCRIPTION
## Summary

- Fix `pyarrow.lib.ArrowInvalid` on multi-field BDP calls when Bloomberg returns mixed Python types (e.g., `float` for `FUT_CONT_SIZE`, `str` for `FUT_VAL_PT`)
- New `_events_to_table()` builds Arrow tables directly from event dicts with automatic type coercion fallback (stringify on `ArrowInvalid`)
- Protects post-transform `pa.Table.from_pandas()` with the same stringify fallback for object columns

## Root Cause

Bloomberg's `fld.getValue()` returns native Python types matching the field's Bloomberg data type:
- `Double` fields → `float` (e.g., `FUT_CONT_SIZE` = `50.0`)
- `String` fields → `str` (e.g., `FUT_VAL_PT` = `'50.00'`)

When both land in the same Arrow value column, `pa.array([50.0, '50.00'])` raises `ArrowInvalid`. The existing `pd.to_numeric()` fallback was broken because `pd.to_numeric('50.00')` succeeds (doesn't raise), so the except branch never fires.

## Fix

`_events_to_table()` in `pipeline_core.py`:
1. Collects column names from all events (handles non-uniform keys)
2. For each column: tries `pa.array()` with type inference (fast path)
3. On `ArrowInvalid`/`ArrowTypeError`: stringifies non-None values → `pa.string()` (slow path, preserves nulls)

No pandas intermediary — pure Arrow construction.

## Tests

- **16 unit tests** (`test_events_to_table.py`): basic contract, mixed-type columns (float+str, int+str, float+date, kitchen sink), null handling, non-uniform keys, pipeline integration
- **2 live regression tests** (`test_live_endpoints.py`): exact bug scenario with `ES1 Index` + `NQ1 Index` using `FUT_CONT_SIZE`/`FUT_VAL_PT`
- Full suite: **587 unit tests pass**, both live tests pass