### PR TITLE
feat: CDX, fixed income, and options analytics modules

### DIFF
--- a/.github/workflows/auto_ci.yml
+++ b/.github/workflows/auto_ci.yml
@@ -46,9 +46,17 @@ jobs:
       run: |
         # Find non-ASCII characters in Python source files (allows CJK for ticker tests)
         # Excludes __pycache__ directories
-        if grep -rPn '[^\x00-\x7F\p{Han}\p{Katakana}\p{Hiragana}]' --include='*.py' xbbg/ --exclude-dir=__pycache__; then
-          echo "ERROR: Non-ASCII characters found in Python source files (see above)"
+        # Show ALL violations at once so every issue can be fixed in a single pass
+        HITS=$(grep -rPn '[^\x00-\x7F\p{Han}\p{Katakana}\p{Hiragana}]' --include='*.py' xbbg/ --exclude-dir=__pycache__ || true)
+        if [ -n "$HITS" ]; then
+          echo "=========================================="
+          echo " Non-ASCII characters found in source"
+          echo "=========================================="
+          echo "$HITS"
+          echo ""
+          echo "Total violations: $(echo "$HITS" | wc -l)"
           echo "Allowed: ASCII + CJK/Japanese characters (for ticker tests)"
+          echo "=========================================="
           exit 1
         fi
     - name: Test with pytest

--- a/scripts/cdx_request.py
+++ b/scripts/cdx_request.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python
+"""CDX index resolution and analytics verification script.
+
+Tests ticker resolution (IG + HY), active series selection, and all CDX
+analytics functions against a live Bloomberg terminal.
+
+Usage:
+    uv run python -X utf8 scripts/cdx_request.py
+
+Requires Bloomberg Terminal connection.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import sys
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(levelname)-7s %(name)s:%(filename)s:%(lineno)d %(message)s",
+)
+# Silence noisy loggers
+logging.getLogger("asyncio").setLevel(logging.WARNING)
+logger = logging.getLogger(__name__)
+
+try:
+    from xbbg.ext.cdx import (
+        _CDX_FIELDS,
+        active_cdx,
+        cdx_basis,
+        cdx_cashflows,
+        cdx_curve,
+        cdx_default_prob,
+        cdx_defaults,
+        cdx_info,
+        cdx_pricing,
+        cdx_risk,
+        cdx_ticker,
+    )
+except ImportError:
+    print("xbbg not installed. Run: pip install -e .")
+    sys.exit(1)
+
+
+# --- Test tickers ---
+GEN_IG = "CDX IG CDSI GEN 5Y Corp"
+GEN_HY = "CDX HY CDSI GEN 5Y Corp"
+RESOLVE_DATE = "2026-02-16"
+
+
+def _to_printable(obj: object) -> object:
+    """Convert Narwhals / PyArrow frames to pandas for readable output."""
+    to_native = getattr(obj, "to_native", None)
+    if callable(to_native):
+        obj = to_native()
+    to_pandas = getattr(obj, "to_pandas", None)
+    if callable(to_pandas):
+        obj = to_pandas()
+    return obj
+
+
+def _safe_print(obj: object) -> None:
+    """Print with Narwhals-to-native conversion and UTF-8 fallback."""
+    obj = _to_printable(obj)
+    try:
+        print(obj)
+    except UnicodeEncodeError:
+        buf = io.StringIO()
+        print(obj, file=buf)
+        sys.stdout.buffer.write(buf.getvalue().encode("utf-8", errors="replace"))
+        sys.stdout.buffer.write(b"\n")
+
+
+def _section(title: str) -> None:
+    print(f"\n{'=' * 60}")
+    print(f"  {title}")
+    print(f"{'=' * 60}")
+
+
+# ------------------------------------------------------------------
+# 1. Ticker resolution
+# ------------------------------------------------------------------
+
+
+def test_ticker_resolution() -> tuple[str, str]:
+    """Resolve IG (no version) and HY (with version) generic tickers."""
+    _section("TICKER RESOLUTION")
+
+    # IG — expect: CDX IG CDSI S45 5Y Corp (VERSION=1, no V token)
+    ig = cdx_ticker(gen_ticker=GEN_IG, dt=RESOLVE_DATE)
+    print(f"\nIG: {GEN_IG}")
+    print(f" ->  {ig!r}")
+
+    # HY — expect: CDX HY CDSI S45 V2 5Y Corp (VERSION>1, separate V token)
+    hy = cdx_ticker(gen_ticker=GEN_HY, dt=RESOLVE_DATE)
+    print(f"\nHY: {GEN_HY}")
+    print(f" ->  {hy!r}")
+
+    return ig, hy
+
+
+# ------------------------------------------------------------------
+# 2. Active CDX
+# ------------------------------------------------------------------
+
+
+def test_active_cdx() -> tuple[str, str]:
+    """Test active_cdx for both IG and HY."""
+    _section("ACTIVE CDX")
+
+    ig_active = active_cdx(gen_ticker=GEN_IG, dt=RESOLVE_DATE)
+    print(f"\nIG active: {GEN_IG}")
+    print(f"        ->  {ig_active!r}")
+
+    hy_active = active_cdx(gen_ticker=GEN_HY, dt=RESOLVE_DATE)
+    print(f"\nHY active: {GEN_HY}")
+    print(f"        ->  {hy_active!r}")
+
+    return ig_active, hy_active
+
+
+# ------------------------------------------------------------------
+# 3. CDX Info
+# ------------------------------------------------------------------
+
+
+def test_cdx_info(ig_ticker: str, hy_ticker: str) -> None:
+    _section("CDX INFO")
+
+    print(f"\n--- cdx_info({ig_ticker}) ---")
+    _safe_print(cdx_info(ig_ticker))
+
+    print(f"\n--- cdx_info({hy_ticker}) ---")
+    _safe_print(cdx_info(hy_ticker))
+
+
+# ------------------------------------------------------------------
+# 4. CDX Defaults
+# ------------------------------------------------------------------
+
+
+def test_cdx_defaults(hy_ticker: str) -> None:
+    _section("CDX DEFAULTS (HY only)")
+
+    print(f"\n--- cdx_defaults({hy_ticker}) ---")
+    _safe_print(cdx_defaults(hy_ticker))
+
+
+# ------------------------------------------------------------------
+# 5. CDX Pricing
+# ------------------------------------------------------------------
+
+
+def test_cdx_pricing(ig_ticker: str, hy_ticker: str) -> None:
+    _section("CDX PRICING")
+
+    print(f"\n--- cdx_pricing({ig_ticker}) ---")
+    _safe_print(cdx_pricing(ig_ticker))
+
+    print(f"\n--- cdx_pricing({hy_ticker}) ---")
+    _safe_print(cdx_pricing(hy_ticker))
+
+    # Default HY recovery rate is 0.30; try both to show the override works
+    print(f"\n--- cdx_pricing({hy_ticker}, recovery_rate=0.30) [same as default] ---")
+    _safe_print(cdx_pricing(hy_ticker, recovery_rate=0.30))
+
+    print(f"\n--- cdx_pricing({hy_ticker}, recovery_rate=0.50) [override to 50%] ---")
+    _safe_print(cdx_pricing(hy_ticker, recovery_rate=0.50))
+
+
+# ------------------------------------------------------------------
+# 6. CDX Risk
+# ------------------------------------------------------------------
+
+
+def test_cdx_risk(ig_ticker: str) -> None:
+    _section("CDX RISK")
+
+    print(f"\n--- cdx_risk({ig_ticker}) ---")
+    _safe_print(cdx_risk(ig_ticker))
+
+
+# ------------------------------------------------------------------
+# 7. CDX Basis
+# ------------------------------------------------------------------
+
+
+def test_cdx_basis(ig_ticker: str) -> None:
+    _section("CDX BASIS")
+
+    print(f"\n--- cdx_basis({ig_ticker}) ---")
+    _safe_print(cdx_basis(ig_ticker))
+
+
+# ------------------------------------------------------------------
+# 8. CDX Default Probability
+# ------------------------------------------------------------------
+
+
+def test_cdx_default_prob(ig_ticker: str) -> None:
+    _section("CDX DEFAULT PROBABILITY")
+
+    print(f"\n--- cdx_default_prob({ig_ticker}) ---")
+    _safe_print(cdx_default_prob(ig_ticker))
+
+
+# ------------------------------------------------------------------
+# 9. CDX Cashflows
+# ------------------------------------------------------------------
+
+
+def test_cdx_cashflows(ig_ticker: str) -> None:
+    _section("CDX CASHFLOWS")
+
+    print(f"\n--- cdx_cashflows({ig_ticker}) ---")
+    _safe_print(cdx_cashflows(ig_ticker))
+
+
+# ------------------------------------------------------------------
+# 10. CDX Curve
+# ------------------------------------------------------------------
+
+
+def test_cdx_curve() -> None:
+    _section("CDX CURVE")
+
+    print(f"\n--- cdx_curve({GEN_IG}, tenors=['3Y','5Y','7Y','10Y']) ---")
+    _safe_print(cdx_curve(GEN_IG))
+
+
+# ------------------------------------------------------------------
+# Main
+# ------------------------------------------------------------------
+
+
+def main() -> None:
+    print(f"IG generic  : {GEN_IG}")
+    print(f"HY generic  : {GEN_HY}")
+    print(f"Resolve date: {RESOLVE_DATE}\n")
+
+    # 1. Ticker resolution (IG + HY)
+    ig, hy = test_ticker_resolution()
+
+    # 2. Active CDX
+    ig_active, hy_active = test_active_cdx()
+
+    # Use active tickers for remaining tests
+    ig_t = ig_active or ig
+    hy_t = hy_active or hy
+
+    # 3-9. Analytics functions
+    test_cdx_info(ig_t, hy_t)
+    test_cdx_defaults(hy_t)
+    test_cdx_pricing(ig_t, hy_t)
+    test_cdx_risk(ig_t)
+    test_cdx_basis(ig_t)
+    test_cdx_default_prob(ig_t)
+    test_cdx_cashflows(ig_t)
+    test_cdx_curve()
+
+    _section("ALL TESTS COMPLETE")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/cdx_request.py
+++ b/scripts/cdx_request.py
@@ -87,12 +87,12 @@ def test_ticker_resolution() -> tuple[str, str]:
     """Resolve IG (no version) and HY (with version) generic tickers."""
     _section("TICKER RESOLUTION")
 
-    # IG — expect: CDX IG CDSI S45 5Y Corp (VERSION=1, no V token)
+    # IG -- expect: CDX IG CDSI S45 5Y Corp (VERSION=1, no V token)
     ig = cdx_ticker(gen_ticker=GEN_IG, dt=RESOLVE_DATE)
     print(f"\nIG: {GEN_IG}")
     print(f" ->  {ig!r}")
 
-    # HY — expect: CDX HY CDSI S45 V2 5Y Corp (VERSION>1, separate V token)
+    # HY -- expect: CDX HY CDSI S45 V2 5Y Corp (VERSION>1, separate V token)
     hy = cdx_ticker(gen_ticker=GEN_HY, dt=RESOLVE_DATE)
     print(f"\nHY: {GEN_HY}")
     print(f" ->  {hy!r}")

--- a/scripts/fi_request.py
+++ b/scripts/fi_request.py
@@ -134,11 +134,11 @@ def test_bond_spreads() -> None:
     print(f"\n--- bond_spreads({TREASURY_10Y}) ---")
     _safe_print(bond_spreads(TREASURY_10Y))
 
-    print(f"\n--- bond_spreads({CORP_BOND}) [corporate — richer spread data] ---")
+    print(f"\n--- bond_spreads({CORP_BOND}) [corporate -- richer spread data] ---")
     try:
         _safe_print(bond_spreads(CORP_BOND))
     except Exception as e:
-        print(f"  (error: {e} — corporate ticker may need adjustment)")
+        print(f"  (error: {e} -- corporate ticker may need adjustment)")
 
 
 # ------------------------------------------------------------------

--- a/scripts/fi_request.py
+++ b/scripts/fi_request.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python
+"""Fixed income bond analytics verification script.
+
+Tests all bond analytics functions (bond_info, bond_risk, bond_spreads,
+bond_cashflows, bond_key_rates, bond_curve) and the enhanced yas() function
+against a live Bloomberg terminal.
+
+Usage:
+    uv run python -X utf8 scripts/fi_request.py
+
+Requires Bloomberg Terminal connection.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import sys
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(levelname)-7s %(name)s:%(filename)s:%(lineno)d %(message)s",
+)
+# Silence noisy loggers
+logging.getLogger("asyncio").setLevel(logging.WARNING)
+logger = logging.getLogger(__name__)
+
+try:
+    from xbbg.ext import YieldType, yas
+    from xbbg.ext.bonds import (
+        bond_cashflows,
+        bond_curve,
+        bond_info,
+        bond_key_rates,
+        bond_risk,
+        bond_spreads,
+    )
+except ImportError:
+    print("xbbg not installed. Run: pip install -e .")
+    sys.exit(1)
+
+
+# --- Test tickers ---
+# 10yr US Treasury (confirmed working with all FI fields)
+TREASURY_10Y = "/isin/US91282CNC19"
+# A second bond for curve comparison
+TREASURY_5Y = "T 4 02/28/31 Govt"
+# Corporate bond (for spread analysis)
+CORP_BOND = "AAPL 4.1 08/08/62 Corp"
+
+
+def _to_printable(obj: object) -> object:
+    """Convert Narwhals / PyArrow frames to pandas for readable output."""
+    to_native = getattr(obj, "to_native", None)
+    if callable(to_native):
+        obj = to_native()
+    to_pandas = getattr(obj, "to_pandas", None)
+    if callable(to_pandas):
+        obj = to_pandas()
+    return obj
+
+
+def _safe_print(obj: object) -> None:
+    """Print with Narwhals-to-native conversion and UTF-8 fallback."""
+    obj = _to_printable(obj)
+    try:
+        print(obj)
+    except UnicodeEncodeError:
+        buf = io.StringIO()
+        print(obj, file=buf)
+        sys.stdout.buffer.write(buf.getvalue().encode("utf-8", errors="replace"))
+        sys.stdout.buffer.write(b"\n")
+
+
+def _section(title: str) -> None:
+    print(f"\n{'=' * 60}")
+    print(f"  {title}")
+    print(f"{'=' * 60}")
+
+
+# ------------------------------------------------------------------
+# 1. Enhanced YAS
+# ------------------------------------------------------------------
+
+
+def test_yas() -> None:
+    _section("ENHANCED YAS")
+
+    print(f"\n--- yas({TREASURY_10Y}) [basic yield] ---")
+    _safe_print(yas(TREASURY_10Y))
+
+    print(f"\n--- yas({TREASURY_10Y}, flds=['YAS_BOND_YLD', 'YAS_MOD_DUR', 'YAS_ZSPREAD']) ---")
+    _safe_print(yas(TREASURY_10Y, ["YAS_BOND_YLD", "YAS_MOD_DUR", "YAS_ZSPREAD"]))
+
+    print(f"\n--- yas({TREASURY_10Y}, flds='YAS_BOND_PX', yield_=4.5) ---")
+    _safe_print(yas(TREASURY_10Y, flds="YAS_BOND_PX", yield_=4.5))
+
+    print(f"\n--- yas({TREASURY_10Y}, yield_type=YieldType.YTW) ---")
+    _safe_print(yas(TREASURY_10Y, yield_type=YieldType.YTW))
+
+
+# ------------------------------------------------------------------
+# 2. Bond Info
+# ------------------------------------------------------------------
+
+
+def test_bond_info() -> None:
+    _section("BOND INFO")
+
+    print(f"\n--- bond_info({TREASURY_10Y}) ---")
+    _safe_print(bond_info(TREASURY_10Y))
+
+
+# ------------------------------------------------------------------
+# 3. Bond Risk
+# ------------------------------------------------------------------
+
+
+def test_bond_risk() -> None:
+    _section("BOND RISK")
+
+    print(f"\n--- bond_risk({TREASURY_10Y}) ---")
+    _safe_print(bond_risk(TREASURY_10Y))
+
+
+# ------------------------------------------------------------------
+# 4. Bond Spreads
+# ------------------------------------------------------------------
+
+
+def test_bond_spreads() -> None:
+    _section("BOND SPREADS")
+
+    print(f"\n--- bond_spreads({TREASURY_10Y}) ---")
+    _safe_print(bond_spreads(TREASURY_10Y))
+
+    print(f"\n--- bond_spreads({CORP_BOND}) [corporate — richer spread data] ---")
+    try:
+        _safe_print(bond_spreads(CORP_BOND))
+    except Exception as e:
+        print(f"  (error: {e} — corporate ticker may need adjustment)")
+
+
+# ------------------------------------------------------------------
+# 5. Bond Cashflows
+# ------------------------------------------------------------------
+
+
+def test_bond_cashflows() -> None:
+    _section("BOND CASHFLOWS")
+
+    print(f"\n--- bond_cashflows({TREASURY_10Y}) ---")
+    _safe_print(bond_cashflows(TREASURY_10Y))
+
+
+# ------------------------------------------------------------------
+# 6. Bond Key Rates
+# ------------------------------------------------------------------
+
+
+def test_bond_key_rates() -> None:
+    _section("BOND KEY RATES")
+
+    print(f"\n--- bond_key_rates({TREASURY_10Y}) ---")
+    _safe_print(bond_key_rates(TREASURY_10Y))
+
+
+# ------------------------------------------------------------------
+# 7. Bond Curve
+# ------------------------------------------------------------------
+
+
+def test_bond_curve() -> None:
+    _section("BOND CURVE")
+
+    print(f"\n--- bond_curve([{TREASURY_10Y}, {TREASURY_5Y}]) ---")
+    _safe_print(bond_curve([TREASURY_10Y, TREASURY_5Y]))
+
+
+# ------------------------------------------------------------------
+# Main
+# ------------------------------------------------------------------
+
+
+def main() -> None:
+    print("Fixed Income Bond Analytics Verification")
+    print(f"Treasury 10Y: {TREASURY_10Y}")
+    print(f"Treasury 5Y : {TREASURY_5Y}")
+    print(f"Corporate   : {CORP_BOND}")
+
+    test_yas()
+    test_bond_info()
+    test_bond_risk()
+    test_bond_spreads()
+    test_bond_cashflows()
+    test_bond_key_rates()
+    test_bond_curve()
+
+    _section("ALL TESTS COMPLETE")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/options_request.py
+++ b/scripts/options_request.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python
+"""Options analytics verification script.
+
+Tests all options analytics functions (option_info, option_greeks, option_pricing,
+option_chain, option_chain_bql, option_screen) against a live Bloomberg terminal.
+
+Usage:
+    uv run python -X utf8 scripts/options_request.py
+
+Requires Bloomberg Terminal connection.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import sys
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(levelname)-7s %(name)s:%(filename)s:%(lineno)d %(message)s",
+)
+# Silence noisy loggers
+logging.getLogger("asyncio").setLevel(logging.WARNING)
+logger = logging.getLogger(__name__)
+
+try:
+    from xbbg.ext.options import (
+        PutCall,
+        StrikeRef,
+        option_chain,
+        option_chain_bql,
+        option_greeks,
+        option_info,
+        option_pricing,
+        option_screen,
+    )
+except ImportError:
+    print("xbbg not installed. Run: pip install -e .")
+    sys.exit(1)
+
+
+# --- Test tickers ---
+# Deep ITM call (confirmed working with all options fields)
+OPT_TICKER = "SPY US 03/20/26 C600 Equity"
+# Underlying for chain functions
+UNDERLYING = "SPY US Equity"
+
+
+def _to_printable(obj: object) -> object:
+    """Convert Narwhals / PyArrow frames to pandas for readable output."""
+    to_native = getattr(obj, "to_native", None)
+    if callable(to_native):
+        obj = to_native()
+    to_pandas = getattr(obj, "to_pandas", None)
+    if callable(to_pandas):
+        obj = to_pandas()
+    return obj
+
+
+def _safe_print(obj: object) -> None:
+    """Print with Narwhals-to-native conversion and UTF-8 fallback."""
+    obj = _to_printable(obj)
+    try:
+        print(obj)
+    except UnicodeEncodeError:
+        buf = io.StringIO()
+        print(obj, file=buf)
+        sys.stdout.buffer.write(buf.getvalue().encode("utf-8", errors="replace"))
+        sys.stdout.buffer.write(b"\n")
+
+
+def _section(title: str) -> None:
+    print(f"\n{'=' * 60}")
+    print(f"  {title}")
+    print(f"{'=' * 60}")
+
+
+# ------------------------------------------------------------------
+# 1. Option Info
+# ------------------------------------------------------------------
+
+
+def test_option_info() -> None:
+    _section("OPTION INFO")
+
+    print(f"\n--- option_info({OPT_TICKER}) ---")
+    _safe_print(option_info(OPT_TICKER))
+
+
+# ------------------------------------------------------------------
+# 2. Option Greeks
+# ------------------------------------------------------------------
+
+
+def test_option_greeks() -> None:
+    _section("OPTION GREEKS")
+
+    print(f"\n--- option_greeks({OPT_TICKER}) ---")
+    _safe_print(option_greeks(OPT_TICKER))
+
+
+# ------------------------------------------------------------------
+# 3. Option Pricing
+# ------------------------------------------------------------------
+
+
+def test_option_pricing() -> None:
+    _section("OPTION PRICING")
+
+    print(f"\n--- option_pricing({OPT_TICKER}) ---")
+    _safe_print(option_pricing(OPT_TICKER))
+
+
+# ------------------------------------------------------------------
+# 4. Option Chain
+# ------------------------------------------------------------------
+
+
+def test_option_chain() -> None:
+    _section("OPTION CHAIN")
+
+    print(
+        f"\n--- option_chain({UNDERLYING}, put_call=PutCall.CALL, expiry_dt='20260320', strike=StrikeRef.ATM, points=5) ---"
+    )
+    _safe_print(option_chain(UNDERLYING, put_call=PutCall.CALL, expiry_dt="20260320", strike=StrikeRef.ATM, points=5))
+
+
+# ------------------------------------------------------------------
+# 5. Option Chain BQL
+# ------------------------------------------------------------------
+
+
+def test_option_chain_bql() -> None:
+    _section("OPTION CHAIN BQL")
+
+    print(
+        f"\n--- option_chain_bql({UNDERLYING}, put_call=PutCall.CALL, expiry_start='2026-03-20', expiry_end='2026-03-20', strike_low=675, strike_high=690, delta_low=0.3, delta_high=0.7, min_open_int=100) ---"
+    )
+    _safe_print(
+        option_chain_bql(
+            UNDERLYING,
+            put_call=PutCall.CALL,
+            expiry_start="2026-03-20",
+            expiry_end="2026-03-20",
+            strike_low=675,
+            strike_high=690,
+            delta_low=0.3,
+            delta_high=0.7,
+            min_open_int=100,
+        )
+    )
+
+
+# ------------------------------------------------------------------
+# 6. Option Screen
+# ------------------------------------------------------------------
+
+
+def test_option_screen() -> None:
+    _section("OPTION SCREEN")
+
+    print(f"\n--- option_screen(['SPY US 03/20/26 C680 Equity', 'SPY US 03/20/26 P680 Equity']) ---")
+    _safe_print(option_screen(["SPY US 03/20/26 C680 Equity", "SPY US 03/20/26 P680 Equity"]))
+
+
+# ------------------------------------------------------------------
+# Main
+# ------------------------------------------------------------------
+
+
+def main() -> None:
+    print("Options Analytics Verification")
+    print(f"Option Ticker: {OPT_TICKER}")
+    print(f"Underlying   : {UNDERLYING}")
+
+    test_option_info()
+    test_option_greeks()
+    test_option_pricing()
+    test_option_chain()
+    test_option_chain_bql()
+    test_option_screen()
+
+    _section("ALL TESTS COMPLETE")
+
+
+if __name__ == "__main__":
+    main()

--- a/xbbg/api/fixed_income/__init__.py
+++ b/xbbg/api/fixed_income/__init__.py
@@ -5,4 +5,5 @@ yield and spread analysis (YAS) and bond analytics.
 """
 
 from xbbg.ext.bonds import *
+
 from .yas import *

--- a/xbbg/api/fixed_income/__init__.py
+++ b/xbbg/api/fixed_income/__init__.py
@@ -1,7 +1,8 @@
 """Bloomberg Fixed Income API.
 
 Provides convenience functions for fixed income analytics including
-yield and spread analysis (YAS).
+yield and spread analysis (YAS) and bond analytics.
 """
 
+from xbbg.ext.bonds import *
 from .yas import *

--- a/xbbg/api/fixed_income/yas.py
+++ b/xbbg/api/fixed_income/yas.py
@@ -1,14 +1,14 @@
 """Bloomberg Yield & Spread Analysis (YAS) API.
 
-Provides convenience functions for fixed income yield and spread calculations.
+This module provides convenience functions for fixed income yield and spread calculations.
 """
 
 from __future__ import annotations
 
+from datetime import datetime
 from enum import IntEnum
 import logging
-
-import pandas as pd
+from typing import Any
 
 from xbbg.backend import Backend, Format
 
@@ -20,7 +20,7 @@ __all__ = ["yas", "YieldType"]
 class YieldType(IntEnum):
     """Bloomberg YAS yield calculation type (YAS_YLD_FLAG override).
 
-    Used to specify whether to calculate Yield to Maturity or Yield to Call.
+    Used to specify the yield calculation convention.
 
     Examples:
         >>> from xbbg.api.fixed_income import YieldType
@@ -28,28 +28,32 @@ class YieldType(IntEnum):
         <YieldType.YTM: 1>
         >>> YieldType.YTC
         <YieldType.YTC: 2>
-        >>> int(YieldType.YTM)
-        1
+        >>> int(YieldType.YTW)
+        3
     """
 
     YTM = 1  # Yield to Maturity
     YTC = 2  # Yield to Call
+    YTW = 3  # Yield to Worst
+    YTP = 4  # Yield to Put
+    CFY = 5  # Cash Flow Yield
 
 
 def yas(
     tickers: str | list[str],
     flds: str | list[str] = "YAS_BOND_YLD",
     *,
-    settle_dt: str | pd.Timestamp | None = None,
+    settle_dt: str | datetime | None = None,
     yield_type: YieldType | int | None = None,
     spread: float | None = None,
     yield_: float | None = None,
     price: float | None = None,
     benchmark: str | None = None,
+    workout_dt: str | datetime | None = None,
     backend: Backend | None = None,
     format: Format | None = None,
     **kwargs,
-) -> pd.DataFrame:
+) -> Any:
     """Bloomberg Yield & Spread Analysis (YAS) data.
 
     Convenience wrapper for YAS fields with commonly-used overrides as named parameters.
@@ -72,6 +76,8 @@ def yas(
             Maps to YAS_BOND_PX override.
         benchmark: Benchmark bond ticker for spread calculations.
             Maps to YAS_BNCHMRK_BOND override.
+        workout_dt: Workout date for yield-to-worst/call calculations (YYYYMMDD or datetime).
+            Maps to YAS_WORKOUT_DT override.
         backend: Output backend (e.g., Backend.PANDAS, Backend.POLARS).
             Defaults to global setting.
         format: Output format (e.g., Format.WIDE, Format.LONG).
@@ -88,25 +94,28 @@ def yas(
         >>> from xbbg.api.fixed_income import YieldType  # doctest: +SKIP
         >>>
         >>> # Get yield to maturity for a bond
-        >>> blp.yas('US912810TD00 Govt')  # doctest: +SKIP
+        >>> blp.yas("US912810TD00 Govt")  # doctest: +SKIP
         >>>
         >>> # Get yield with custom settlement date
-        >>> blp.yas('US912810TD00 Govt', settle_dt='20240115')  # doctest: +SKIP
+        >>> blp.yas("US912810TD00 Govt", settle_dt="20240115")  # doctest: +SKIP
         >>>
         >>> # Get yield to call instead of yield to maturity
-        >>> blp.yas('XYZ Corp', yield_type=YieldType.YTC)  # doctest: +SKIP
+        >>> blp.yas("XYZ Corp", yield_type=YieldType.YTC)  # doctest: +SKIP
+        >>>
+        >>> # Get yield to worst
+        >>> blp.yas("XYZ Corp", yield_type=YieldType.YTW)  # doctest: +SKIP
         >>>
         >>> # Calculate yield from a given price
-        >>> blp.yas('US912810TD00 Govt', price=98.5)  # doctest: +SKIP
+        >>> blp.yas("US912810TD00 Govt", price=98.5)  # doctest: +SKIP
         >>>
         >>> # Calculate price from a given yield
-        >>> blp.yas('US912810TD00 Govt', flds='YAS_BOND_PX', yield_=4.5)  # doctest: +SKIP
+        >>> blp.yas("US912810TD00 Govt", flds="YAS_BOND_PX", yield_=4.5)  # doctest: +SKIP
         >>>
         >>> # Get spread to a specific benchmark
-        >>> blp.yas('XYZ Corp', flds='YAS_YLD_SPREAD', benchmark='US912810TD00 Govt')  # doctest: +SKIP
+        >>> blp.yas("XYZ Corp", flds="YAS_YLD_SPREAD", benchmark="US912810TD00 Govt")  # doctest: +SKIP
         >>>
         >>> # Get multiple YAS analytics
-        >>> blp.yas('US912810TD00 Govt', ['YAS_BOND_YLD', 'YAS_MOD_DUR', 'YAS_Z_SPREAD'])  # doctest: +SKIP
+        >>> blp.yas("US912810TD00 Govt", ["YAS_BOND_YLD", "YAS_MOD_DUR", "YAS_Z_SPREAD"])  # doctest: +SKIP
     """
     from xbbg.api.reference import bdp
 
@@ -120,16 +129,16 @@ def yas(
         if isinstance(settle_dt, str):
             # Try to parse and reformat to ensure consistent format
             try:
-                dt = pd.Timestamp(settle_dt)
-                if dt is not pd.NaT:
-                    formatted_dt = f"{dt.year:04d}{dt.month:02d}{dt.day:02d}"
+                # Handle various date string formats
+                dt = datetime.fromisoformat(settle_dt.replace("/", "-"))
+                formatted_dt = f"{dt.year:04d}{dt.month:02d}{dt.day:02d}"
             except (ValueError, TypeError):
-                # If parsing fails, pass through as-is
+                # If parsing fails, pass through as-is (might already be YYYYMMDD)
                 formatted_dt = settle_dt
-        elif isinstance(settle_dt, pd.Timestamp) and settle_dt is not pd.NaT:
+        elif isinstance(settle_dt, datetime):
             formatted_dt = f"{settle_dt.year:04d}{settle_dt.month:02d}{settle_dt.day:02d}"
         else:
-            formatted_dt = str(settle_dt) if settle_dt is not None else None
+            formatted_dt = str(settle_dt)
 
         if formatted_dt is not None:
             overrides["SETTLE_DT"] = formatted_dt
@@ -149,6 +158,22 @@ def yas(
 
     if benchmark is not None:
         overrides["YAS_BNCHMRK_BOND"] = benchmark
+
+    if workout_dt is not None:
+        # Reuse the same date formatting logic as settle_dt
+        formatted_wo: str | None = None
+        if isinstance(workout_dt, str):
+            try:
+                dt = datetime.fromisoformat(workout_dt.replace("/", "-"))
+                formatted_wo = f"{dt.year:04d}{dt.month:02d}{dt.day:02d}"
+            except (ValueError, TypeError):
+                formatted_wo = workout_dt
+        elif isinstance(workout_dt, datetime):
+            formatted_wo = f"{workout_dt.year:04d}{workout_dt.month:02d}{workout_dt.day:02d}"
+        else:
+            formatted_wo = str(workout_dt)
+        if formatted_wo is not None:
+            overrides["YAS_WORKOUT_DT"] = formatted_wo
 
     # Merge with any additional kwargs overrides (kwargs take precedence)
     overrides.update(kwargs)

--- a/xbbg/core/strategies/block_data.py
+++ b/xbbg/core/strategies/block_data.py
@@ -81,7 +81,7 @@ class BlockDataTransformer:
         rename_map = {col: standardize_col_name(col) for col in df.columns}
 
         # Deduplicate: when different original names map to the same
-        # standardized name (e.g. "ticker" and "Ticker" both → "ticker"),
+        # standardized name (e.g. "ticker" and "Ticker" both -> "ticker"),
         # suffix later occurrences so narwhals/polars don't reject the rename.
         seen: dict[str, int] = {}
         for old_name in list(rename_map):

--- a/xbbg/core/strategies/block_data.py
+++ b/xbbg/core/strategies/block_data.py
@@ -79,6 +79,19 @@ class BlockDataTransformer:
             return name.lower().replace(" ", "_").replace("-", "_")
 
         rename_map = {col: standardize_col_name(col) for col in df.columns}
+
+        # Deduplicate: when different original names map to the same
+        # standardized name (e.g. "ticker" and "Ticker" both → "ticker"),
+        # suffix later occurrences so narwhals/polars don't reject the rename.
+        seen: dict[str, int] = {}
+        for old_name in list(rename_map):
+            new_name = rename_map[old_name]
+            if new_name in seen:
+                seen[new_name] += 1
+                rename_map[old_name] = f"{new_name}_{seen[new_name]}"
+            else:
+                seen[new_name] = 0
+
         df = df.rename(rename_map)
 
         return nw.to_native(df)

--- a/xbbg/ext/__init__.py
+++ b/xbbg/ext/__init__.py
@@ -26,6 +26,17 @@ Functions:
     bond_cashflows: Bond cash flow schedule
     bond_key_rates: Bond key rate durations and risks
     bond_curve: Multi-bond relative value analytics
+    PutCall: Enum for option chain put/call filter
+    ChainPeriodicity: Enum for option chain expiry periodicity
+    StrikeRef: Enum for option chain strike reference
+    ExerciseType: Enum for option chain exercise type
+    ExpiryMatch: Enum for option chain expiry matching
+    option_info: Option contract metadata
+    option_greeks: Option Greeks and implied volatility
+    option_pricing: Option pricing, value decomposition, and activity
+    option_chain: Option chain via CHAIN_TICKERS with overrides
+    option_chain_bql: Option chain via BQL with rich filtering
+    option_screen: Multi-option comparison analytics
 """
 
 from __future__ import annotations
@@ -55,6 +66,19 @@ from xbbg.ext.bonds import (
     bond_key_rates,
     bond_risk,
     bond_spreads,
+)
+from xbbg.ext.options import (
+    ChainPeriodicity,
+    ExerciseType,
+    ExpiryMatch,
+    PutCall,
+    StrikeRef,
+    option_chain,
+    option_chain_bql,
+    option_greeks,
+    option_info,
+    option_pricing,
+    option_screen,
 )
 from xbbg.ext.yas import YieldType, yas
 
@@ -94,4 +118,17 @@ __all__ = [
     "bond_cashflows",
     "bond_key_rates",
     "bond_curve",
+    # Options — Enums
+    "PutCall",
+    "ChainPeriodicity",
+    "StrikeRef",
+    "ExerciseType",
+    "ExpiryMatch",
+    # Options — Analytics
+    "option_info",
+    "option_greeks",
+    "option_pricing",
+    "option_chain",
+    "option_chain_bql",
+    "option_screen",
 ]

--- a/xbbg/ext/__init__.py
+++ b/xbbg/ext/__init__.py
@@ -24,7 +24,18 @@ Functions:
 
 from __future__ import annotations
 
-from xbbg.ext.cdx import active_cdx, cdx_ticker
+from xbbg.ext.cdx import (
+    active_cdx,
+    cdx_basis,
+    cdx_cashflows,
+    cdx_curve,
+    cdx_default_prob,
+    cdx_defaults,
+    cdx_info,
+    cdx_pricing,
+    cdx_risk,
+    cdx_ticker,
+)
 from xbbg.ext.currency import adjust_ccy
 from xbbg.ext.dividends import dividend
 from xbbg.ext.earnings import earning
@@ -50,6 +61,15 @@ __all__ = [
     # CDX resolution
     "cdx_ticker",
     "active_cdx",
+    # CDX analytics
+    "cdx_info",
+    "cdx_defaults",
+    "cdx_pricing",
+    "cdx_risk",
+    "cdx_basis",
+    "cdx_default_prob",
+    "cdx_cashflows",
+    "cdx_curve",
     # Fixed income
     "yas",
     "YieldType",

--- a/xbbg/ext/__init__.py
+++ b/xbbg/ext/__init__.py
@@ -108,23 +108,23 @@ __all__ = [
     "cdx_default_prob",
     "cdx_cashflows",
     "cdx_curve",
-    # Fixed income — YAS
+    # Fixed income -- YAS
     "yas",
     "YieldType",
-    # Fixed income — Bond analytics
+    # Fixed income -- Bond analytics
     "bond_info",
     "bond_risk",
     "bond_spreads",
     "bond_cashflows",
     "bond_key_rates",
     "bond_curve",
-    # Options — Enums
+    # Options -- Enums
     "PutCall",
     "ChainPeriodicity",
     "StrikeRef",
     "ExerciseType",
     "ExpiryMatch",
-    # Options — Analytics
+    # Options -- Analytics
     "option_info",
     "option_greeks",
     "option_pricing",

--- a/xbbg/ext/__init__.py
+++ b/xbbg/ext/__init__.py
@@ -20,6 +20,12 @@ Functions:
     active_cdx: Active CDX contract selection
     yas: Yield & Spread Analysis calculator
     YieldType: Enum for yield calculation types
+    bond_info: Bond reference metadata
+    bond_risk: Bond duration, convexity, DV01 analytics
+    bond_spreads: Bond spread analytics (OAS, Z-spread, I-spread, ASW)
+    bond_cashflows: Bond cash flow schedule
+    bond_key_rates: Bond key rate durations and risks
+    bond_curve: Multi-bond relative value analytics
 """
 
 from __future__ import annotations
@@ -42,6 +48,14 @@ from xbbg.ext.earnings import earning
 from xbbg.ext.futures import active_futures, fut_ticker
 from xbbg.ext.holdings import corporate_bonds, etf_holdings, preferreds
 from xbbg.ext.turnover import turnover
+from xbbg.ext.bonds import (
+    bond_cashflows,
+    bond_curve,
+    bond_info,
+    bond_key_rates,
+    bond_risk,
+    bond_spreads,
+)
 from xbbg.ext.yas import YieldType, yas
 
 __all__ = [
@@ -70,7 +84,14 @@ __all__ = [
     "cdx_default_prob",
     "cdx_cashflows",
     "cdx_curve",
-    # Fixed income
+    # Fixed income — YAS
     "yas",
     "YieldType",
+    # Fixed income — Bond analytics
+    "bond_info",
+    "bond_risk",
+    "bond_spreads",
+    "bond_cashflows",
+    "bond_key_rates",
+    "bond_curve",
 ]

--- a/xbbg/ext/__init__.py
+++ b/xbbg/ext/__init__.py
@@ -41,6 +41,14 @@ Functions:
 
 from __future__ import annotations
 
+from xbbg.ext.bonds import (
+    bond_cashflows,
+    bond_curve,
+    bond_info,
+    bond_key_rates,
+    bond_risk,
+    bond_spreads,
+)
 from xbbg.ext.cdx import (
     active_cdx,
     cdx_basis,
@@ -58,15 +66,6 @@ from xbbg.ext.dividends import dividend
 from xbbg.ext.earnings import earning
 from xbbg.ext.futures import active_futures, fut_ticker
 from xbbg.ext.holdings import corporate_bonds, etf_holdings, preferreds
-from xbbg.ext.turnover import turnover
-from xbbg.ext.bonds import (
-    bond_cashflows,
-    bond_curve,
-    bond_info,
-    bond_key_rates,
-    bond_risk,
-    bond_spreads,
-)
 from xbbg.ext.options import (
     ChainPeriodicity,
     ExerciseType,
@@ -80,6 +79,7 @@ from xbbg.ext.options import (
     option_pricing,
     option_screen,
 )
+from xbbg.ext.turnover import turnover
 from xbbg.ext.yas import YieldType, yas
 
 __all__ = [

--- a/xbbg/ext/bonds.py
+++ b/xbbg/ext/bonds.py
@@ -1,0 +1,514 @@
+"""Bloomberg Fixed Income Bond Analytics API.
+
+This module provides convenience functions for bond analytics including
+risk measures, spread analysis, cash flows, and key rate durations.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+import logging
+from typing import TYPE_CHECKING
+
+from xbbg.backend import Backend, Format
+
+if TYPE_CHECKING:
+    from xbbg.core.domain.context import BloombergContext
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "bond_info",
+    "bond_risk",
+    "bond_spreads",
+    "bond_cashflows",
+    "bond_key_rates",
+    "bond_curve",
+]
+
+# Bond metadata fields
+_FLD_NAME = "NAME"
+_FLD_SECURITY_DES = "SECURITY_DES"
+_FLD_CRNCY = "CRNCY"
+_FLD_CPNTYP = "CPN_TYP"
+_FLD_CPN = "CPN"
+_FLD_MATURITY = "MATURITY"
+_FLD_PAR_AMT = "PAR_AMT"
+_FLD_AMT_OUTSTANDING = "AMT_OUTSTANDING"
+_FLD_ISSUE_DT = "ISSUE_DT"
+_FLD_COUNTRY = "COUNTRY_ISO"
+_FLD_INDUSTRY_SECTOR = "INDUSTRY_SECTOR"
+_FLD_BB_COMPOSITE = "BB_COMPOSITE"
+_FLD_RTG_SP = "RTG_SP"
+_FLD_RTG_MOODY = "RTG_MOODY"
+_FLD_RTG_FITCH = "RTG_FITCH"
+_FLD_CALLABLE = "CALLABLE"
+_FLD_PUTABLE = "PUTABLE"
+_FLD_SINKABLE = "SINKABLE"
+
+_BOND_INFO_FIELDS: list[str] = [
+    _FLD_NAME,
+    _FLD_SECURITY_DES,
+    _FLD_CRNCY,
+    _FLD_CPNTYP,
+    _FLD_CPN,
+    _FLD_MATURITY,
+    _FLD_PAR_AMT,
+    _FLD_AMT_OUTSTANDING,
+    _FLD_ISSUE_DT,
+    _FLD_COUNTRY,
+    _FLD_INDUSTRY_SECTOR,
+    _FLD_BB_COMPOSITE,
+    _FLD_RTG_SP,
+    _FLD_RTG_MOODY,
+    _FLD_RTG_FITCH,
+    _FLD_CALLABLE,
+    _FLD_PUTABLE,
+    _FLD_SINKABLE,
+]
+
+# Bond risk fields
+_FLD_DUR_ADJ_MID = "DUR_ADJ_MID"
+_FLD_DUR_MID = "DUR_MID"
+_FLD_CNVX_MID = "CNVX_MID"
+_FLD_DUR_ADJ_OAS_MID = "DUR_ADJ_OAS_MID"
+_FLD_OAS_SPREAD_DUR_MID = "OAS_SPREAD_DUR_MID"
+_FLD_CNVX_OAS_MID = "CNVX_OAS_MID"
+_FLD_RISK_MID = "RISK_MID"
+_FLD_RISK_OAS_MID = "RISK_OAS_MID"
+_FLD_YAS_MOD_DUR = "YAS_MOD_DUR"
+_FLD_YAS_RISK = "YAS_RISK"
+
+_BOND_RISK_FIELDS: list[str] = [
+    _FLD_DUR_ADJ_MID,
+    _FLD_DUR_MID,
+    _FLD_CNVX_MID,
+    _FLD_DUR_ADJ_OAS_MID,
+    _FLD_OAS_SPREAD_DUR_MID,
+    _FLD_CNVX_OAS_MID,
+    _FLD_RISK_MID,
+    _FLD_RISK_OAS_MID,
+    _FLD_YAS_MOD_DUR,
+    _FLD_YAS_RISK,
+]
+
+# Bond spread fields
+_FLD_YAS_OAS_SPRD = "YAS_OAS_SPRD"
+_FLD_YAS_ZSPREAD = "YAS_ZSPREAD"
+_FLD_YAS_ISPREAD = "YAS_ISPREAD"
+_FLD_YAS_ASW_SPREAD = "YAS_ASW_SPREAD"
+_FLD_YAS_ISPREAD_TO_GOVT = "YAS_ISPREAD_TO_GOVT"
+_FLD_YAS_YLD_SPREAD = "YAS_YLD_SPREAD"
+_FLD_Z_SPRD_MID = "Z_SPRD_MID"
+_FLD_OAS_SPREAD_MID = "OAS_SPREAD_MID"
+_FLD_YAS_BNCHMRK_BOND = "YAS_BNCHMRK_BOND"
+_FLD_YAS_BNCHMRK_BOND_YLD = "YAS_BNCHMRK_BOND_YLD"
+
+_BOND_SPREAD_FIELDS: list[str] = [
+    _FLD_YAS_OAS_SPRD,
+    _FLD_YAS_ZSPREAD,
+    _FLD_YAS_ISPREAD,
+    _FLD_YAS_ASW_SPREAD,
+    _FLD_YAS_ISPREAD_TO_GOVT,
+    _FLD_YAS_YLD_SPREAD,
+    _FLD_Z_SPRD_MID,
+    _FLD_OAS_SPREAD_MID,
+    _FLD_YAS_BNCHMRK_BOND,
+    _FLD_YAS_BNCHMRK_BOND_YLD,
+]
+
+# Bond cashflow field
+_FLD_DES_CASH_FLOW = "DES_CASH_FLOW"
+
+# Bond key rate duration/risk fields
+_FLD_KRD_1YR = "KEY_RATE_DUR_1YR"
+_FLD_KRD_2YR = "KEY_RATE_DUR_2YR"
+_FLD_KRD_3YR = "KEY_RATE_DUR_3YR"
+_FLD_KRD_4YR = "KEY_RATE_DUR_4YR"
+_FLD_KRD_5YR = "KEY_RATE_DUR_5YR"
+_FLD_KRD_7YR = "KEY_RATE_DUR_7YR"
+_FLD_KRD_8YR = "KEY_RATE_DUR_8YR"
+_FLD_KRD_9YR = "KEY_RATE_DUR_9YR"
+_FLD_KRD_10YR = "KEY_RATE_DUR_10YR"
+_FLD_KRD_15YR = "KEY_RATE_DUR_15YR"
+_FLD_KRD_20YR = "KEY_RATE_DUR_20YR"
+_FLD_KRD_25YR = "KEY_RATE_DUR_25YR"
+_FLD_KRD_30YR = "KEY_RATE_DUR_30YR"
+_FLD_KRR_1Y = "KEY_RATE_RISK_1Y"
+_FLD_KRR_2Y = "KEY_RATE_RISK_2Y"
+_FLD_KRR_3Y = "KEY_RATE_RISK_3Y"
+_FLD_KRR_5Y = "KEY_RATE_RISK_5Y"
+_FLD_KRR_7Y = "KEY_RATE_RISK_7Y"
+_FLD_KRR_10Y = "KEY_RATE_RISK_10Y"
+_FLD_KRR_20Y = "KEY_RATE_RISK_20Y"
+_FLD_KRR_30Y = "KEY_RATE_RISK_30Y"
+
+_BOND_KEY_RATE_FIELDS: list[str] = [
+    _FLD_KRD_1YR,
+    _FLD_KRD_2YR,
+    _FLD_KRD_3YR,
+    _FLD_KRD_4YR,
+    _FLD_KRD_5YR,
+    _FLD_KRD_7YR,
+    _FLD_KRD_8YR,
+    _FLD_KRD_9YR,
+    _FLD_KRD_10YR,
+    _FLD_KRD_15YR,
+    _FLD_KRD_20YR,
+    _FLD_KRD_25YR,
+    _FLD_KRD_30YR,
+    _FLD_KRR_1Y,
+    _FLD_KRR_2Y,
+    _FLD_KRR_3Y,
+    _FLD_KRR_5Y,
+    _FLD_KRR_7Y,
+    _FLD_KRR_10Y,
+    _FLD_KRR_20Y,
+    _FLD_KRR_30Y,
+]
+
+_BOND_CURVE_DEFAULT_FIELDS: list[str] = [
+    "YAS_BOND_YLD",
+    "YAS_MOD_DUR",
+    "YAS_RISK",
+    "YAS_ZSPREAD",
+    "YAS_OAS_SPRD",
+    "DUR_ADJ_MID",
+    "CNVX_MID",
+]
+
+
+def _format_settle_dt(settle_dt: datetime | str | None) -> str | None:
+    """Format settlement date for Bloomberg overrides.
+
+    Uses the same conversion behavior as ``ext.yas``:
+
+    * Parse date strings via ``datetime.fromisoformat`` after replacing ``/`` with ``-``.
+    * Return ``YYYYMMDD`` for parsed strings and ``datetime`` inputs.
+    * If parsing fails, pass the original string through unchanged.
+
+    Args:
+        settle_dt: Settlement date as datetime, string, or None.
+
+    Returns:
+        Formatted settlement date string, or None.
+    """
+    if settle_dt is None:
+        return None
+
+    if isinstance(settle_dt, str):
+        try:
+            dt = datetime.fromisoformat(settle_dt.replace("/", "-"))
+            return f"{dt.year:04d}{dt.month:02d}{dt.day:02d}"
+        except (ValueError, TypeError):
+            return settle_dt
+
+    if isinstance(settle_dt, datetime):
+        return f"{settle_dt.year:04d}{settle_dt.month:02d}{settle_dt.day:02d}"
+
+    return str(settle_dt)
+
+
+def bond_info(
+    ticker: str,
+    *,
+    backend: Backend | None = None,
+    ctx: BloombergContext | None = None,
+    **kwargs,
+):
+    """Return static bond reference metadata in one ``bdp`` call.
+
+    Fields returned (SEMI_LONG rows):
+
+    * ``NAME``, ``SECURITY_DES``, ``CRNCY``
+    * ``CPN_TYP``, ``CPN``, ``MATURITY``
+    * ``PAR_AMT``, ``AMT_OUTSTANDING``, ``ISSUE_DT``
+    * ``COUNTRY_ISO``, ``INDUSTRY_SECTOR``
+    * ``BB_COMPOSITE``, ``RTG_SP``, ``RTG_MOODY``, ``RTG_FITCH``
+    * ``CALLABLE``, ``PUTABLE``, ``SINKABLE``
+
+    Args:
+        ticker: Bond ticker or identifier.
+        backend: Output backend. If ``None``, uses ``Backend.NARWHALS``.
+        ctx: Bloomberg context. If ``None``, extracted from *kwargs*.
+        **kwargs: Legacy kwargs support.
+
+    Returns:
+        DataFrame with bond reference metadata.
+    """
+    from xbbg.api.reference import bdp
+    from xbbg.core.domain.context import split_kwargs
+
+    if ctx is None:
+        split = split_kwargs(**kwargs)
+        ctx = split.infra
+
+    safe_kwargs = ctx.to_kwargs()
+    return bdp(
+        tickers=ticker,
+        flds=_BOND_INFO_FIELDS,
+        backend=backend or Backend.NARWHALS,
+        format=Format.SEMI_LONG,
+        **safe_kwargs,
+    )
+
+
+def bond_risk(
+    ticker: str,
+    *,
+    settle_dt: datetime | str | None = None,
+    backend: Backend | None = None,
+    ctx: BloombergContext | None = None,
+    **kwargs,
+):
+    """Return bond duration, convexity, and DV01 analytics via ``bdp``.
+
+    Fields returned (SEMI_LONG rows):
+
+    * ``DUR_ADJ_MID``, ``DUR_MID``, ``CNVX_MID``
+    * ``DUR_ADJ_OAS_MID``, ``OAS_SPREAD_DUR_MID``, ``CNVX_OAS_MID``
+    * ``RISK_MID``, ``RISK_OAS_MID``
+    * ``YAS_MOD_DUR``, ``YAS_RISK``
+
+    Args:
+        ticker: Bond ticker or identifier.
+        settle_dt: Settlement date override. Maps to ``SETTLE_DT`` override.
+        backend: Output backend. If ``None``, uses ``Backend.NARWHALS``.
+        ctx: Bloomberg context. If ``None``, extracted from *kwargs*.
+        **kwargs: Additional Bloomberg overrides (kwargs override named params).
+
+    Returns:
+        DataFrame with bond risk analytics.
+    """
+    from xbbg.api.reference import bdp
+    from xbbg.core.domain.context import split_kwargs
+
+    if ctx is None:
+        split = split_kwargs(**kwargs)
+        ctx = split.infra
+
+    safe_kwargs = ctx.to_kwargs()
+
+    overrides: dict[str, object] = {}
+    formatted_dt = _format_settle_dt(settle_dt)
+    if formatted_dt is not None:
+        overrides["SETTLE_DT"] = formatted_dt
+    overrides.update(kwargs)
+
+    call_kwargs = {**safe_kwargs, **overrides}
+    return bdp(
+        tickers=ticker,
+        flds=_BOND_RISK_FIELDS,
+        backend=backend or Backend.NARWHALS,
+        format=Format.SEMI_LONG,
+        **call_kwargs,
+    )
+
+
+def bond_spreads(
+    ticker: str,
+    *,
+    settle_dt: datetime | str | None = None,
+    benchmark: str | None = None,
+    backend: Backend | None = None,
+    ctx: BloombergContext | None = None,
+    **kwargs,
+):
+    """Return bond spread analytics and benchmark-relative measures via ``bdp``.
+
+    Fields returned (SEMI_LONG rows):
+
+    * ``YAS_OAS_SPRD``, ``YAS_ZSPREAD``, ``YAS_ISPREAD``
+    * ``YAS_ASW_SPREAD``, ``YAS_ISPREAD_TO_GOVT``, ``YAS_YLD_SPREAD``
+    * ``Z_SPRD_MID``, ``OAS_SPREAD_MID``
+    * ``YAS_BNCHMRK_BOND``, ``YAS_BNCHMRK_BOND_YLD``
+
+    Args:
+        ticker: Bond ticker or identifier.
+        settle_dt: Settlement date override. Maps to ``SETTLE_DT`` override.
+        benchmark: Benchmark bond override. Maps to ``YAS_BNCHMRK_BOND`` override.
+        backend: Output backend. If ``None``, uses ``Backend.NARWHALS``.
+        ctx: Bloomberg context. If ``None``, extracted from *kwargs*.
+        **kwargs: Additional Bloomberg overrides (kwargs override named params).
+
+    Returns:
+        DataFrame with bond spread analytics.
+    """
+    from xbbg.api.reference import bdp
+    from xbbg.core.domain.context import split_kwargs
+
+    if ctx is None:
+        split = split_kwargs(**kwargs)
+        ctx = split.infra
+
+    safe_kwargs = ctx.to_kwargs()
+
+    overrides: dict[str, object] = {}
+    formatted_dt = _format_settle_dt(settle_dt)
+    if formatted_dt is not None:
+        overrides["SETTLE_DT"] = formatted_dt
+    if benchmark is not None:
+        overrides["YAS_BNCHMRK_BOND"] = benchmark
+    overrides.update(kwargs)
+
+    call_kwargs = {**safe_kwargs, **overrides}
+    return bdp(
+        tickers=ticker,
+        flds=_BOND_SPREAD_FIELDS,
+        backend=backend or Backend.NARWHALS,
+        format=Format.SEMI_LONG,
+        **call_kwargs,
+    )
+
+
+def bond_cashflows(
+    ticker: str,
+    *,
+    settle_dt: datetime | str | None = None,
+    backend: Backend | None = None,
+    ctx: BloombergContext | None = None,
+    **kwargs,
+):
+    """Return projected bond cash flow schedule via ``bds``.
+
+    Wraps the ``DES_CASH_FLOW`` bulk field and returns schedule rows including
+    coupon and principal cash flows by payment date.
+
+    Args:
+        ticker: Bond ticker or identifier.
+        settle_dt: Settlement date override. Maps to ``SETTLE_DT`` override.
+        backend: Output backend. If ``None``, uses ``Backend.NARWHALS``.
+        ctx: Bloomberg context. If ``None``, extracted from *kwargs*.
+        **kwargs: Additional Bloomberg overrides (kwargs override named params).
+
+    Returns:
+        DataFrame with bond cash flow schedule.
+    """
+    from xbbg.api.reference.reference import bds
+    from xbbg.core.domain.context import split_kwargs
+
+    if ctx is None:
+        split = split_kwargs(**kwargs)
+        ctx = split.infra
+
+    safe_kwargs = ctx.to_kwargs()
+
+    overrides: dict[str, object] = {}
+    formatted_dt = _format_settle_dt(settle_dt)
+    if formatted_dt is not None:
+        overrides["SETTLE_DT"] = formatted_dt
+    overrides.update(kwargs)
+
+    call_kwargs = {**safe_kwargs, **overrides}
+    return bds(
+        ticker,
+        _FLD_DES_CASH_FLOW,
+        backend=backend or Backend.NARWHALS,
+        format=Format.SEMI_LONG,
+        **call_kwargs,
+    )
+
+
+def bond_key_rates(
+    ticker: str,
+    *,
+    settle_dt: datetime | str | None = None,
+    backend: Backend | None = None,
+    ctx: BloombergContext | None = None,
+    **kwargs,
+):
+    """Return bond key rate durations and key rate risks via ``bdp``.
+
+    Fields returned (SEMI_LONG rows):
+
+    * ``KEY_RATE_DUR_1YR`` through ``KEY_RATE_DUR_30YR``
+    * ``KEY_RATE_RISK_1Y``, ``KEY_RATE_RISK_2Y``, ``KEY_RATE_RISK_3Y``
+    * ``KEY_RATE_RISK_5Y``, ``KEY_RATE_RISK_7Y``, ``KEY_RATE_RISK_10Y``
+    * ``KEY_RATE_RISK_20Y``, ``KEY_RATE_RISK_30Y``
+
+    Args:
+        ticker: Bond ticker or identifier.
+        settle_dt: Settlement date override. Maps to ``SETTLE_DT`` override.
+        backend: Output backend. If ``None``, uses ``Backend.NARWHALS``.
+        ctx: Bloomberg context. If ``None``, extracted from *kwargs*.
+        **kwargs: Additional Bloomberg overrides (kwargs override named params).
+
+    Returns:
+        DataFrame with key rate duration and risk analytics.
+    """
+    from xbbg.api.reference import bdp
+    from xbbg.core.domain.context import split_kwargs
+
+    if ctx is None:
+        split = split_kwargs(**kwargs)
+        ctx = split.infra
+
+    safe_kwargs = ctx.to_kwargs()
+
+    overrides: dict[str, object] = {}
+    formatted_dt = _format_settle_dt(settle_dt)
+    if formatted_dt is not None:
+        overrides["SETTLE_DT"] = formatted_dt
+    overrides.update(kwargs)
+
+    call_kwargs = {**safe_kwargs, **overrides}
+    return bdp(
+        tickers=ticker,
+        flds=_BOND_KEY_RATE_FIELDS,
+        backend=backend or Backend.NARWHALS,
+        format=Format.SEMI_LONG,
+        **call_kwargs,
+    )
+
+
+def bond_curve(
+    tickers: list[str],
+    flds: list[str] | None = None,
+    *,
+    settle_dt: datetime | str | None = None,
+    backend: Backend | None = None,
+    ctx: BloombergContext | None = None,
+    **kwargs,
+):
+    """Return multi-bond relative-value analytics in one ``bdp`` call.
+
+    If *flds* is not provided, defaults to:
+
+    * ``YAS_BOND_YLD``, ``YAS_MOD_DUR``, ``YAS_RISK``
+    * ``YAS_ZSPREAD``, ``YAS_OAS_SPRD``
+    * ``DUR_ADJ_MID``, ``CNVX_MID``
+
+    Args:
+        tickers: List of bond tickers or identifiers.
+        flds: Optional list of fields to request.
+        settle_dt: Settlement date override. Maps to ``SETTLE_DT`` override.
+        backend: Output backend. If ``None``, uses ``Backend.NARWHALS``.
+        ctx: Bloomberg context. If ``None``, extracted from *kwargs*.
+        **kwargs: Additional Bloomberg overrides (kwargs override named params).
+
+    Returns:
+        DataFrame with requested analytics for all provided tickers.
+    """
+    from xbbg.api.reference import bdp
+    from xbbg.core.domain.context import split_kwargs
+
+    if ctx is None:
+        split = split_kwargs(**kwargs)
+        ctx = split.infra
+
+    safe_kwargs = ctx.to_kwargs()
+
+    overrides: dict[str, object] = {}
+    formatted_dt = _format_settle_dt(settle_dt)
+    if formatted_dt is not None:
+        overrides["SETTLE_DT"] = formatted_dt
+    overrides.update(kwargs)
+
+    call_kwargs = {**safe_kwargs, **overrides}
+    return bdp(
+        tickers=tickers,
+        flds=flds or _BOND_CURVE_DEFAULT_FIELDS,
+        backend=backend or Backend.NARWHALS,
+        format=Format.SEMI_LONG,
+        **call_kwargs,
+    )

--- a/xbbg/ext/cdx.py
+++ b/xbbg/ext/cdx.py
@@ -56,14 +56,14 @@ def cdx_ticker(
 
     Uses Bloomberg fields (via ``bdp`` with ``SEMI_LONG`` format):
 
-    * ``ROLLING_SERIES`` – current on-the-run series number
-    * ``VERSION`` – current version (increments on credit events, e.g. CDX HY)
-    * ``ON_THE_RUN_CURRENT_BD_INDICATOR`` – ``'Y'`` if on-the-run
-    * ``CDS_FIRST_ACCRUAL_START_DATE`` – start date of current series trading
+    * ``ROLLING_SERIES`` -- current on-the-run series number
+    * ``VERSION`` -- current version (increments on credit events, e.g. CDX HY)
+    * ``ON_THE_RUN_CURRENT_BD_INDICATOR`` -- ``'Y'`` if on-the-run
+    * ``CDS_FIRST_ACCRUAL_START_DATE`` -- start date of current series trading
 
     Version handling:
         When ``VERSION > 1`` (credit events have occurred, common for CDX HY),
-        a separate version token is inserted: ``S45`` → ``S45 V2``.  When
+        a separate version token is inserted: ``S45`` -> ``S45 V2``.  When
         ``VERSION == 1`` (no defaults, typical for CDX IG) the ticker is left
         as ``S45`` since Bloomberg treats ``S45`` and ``S45 V1`` identically.
 
@@ -202,7 +202,7 @@ def _resolve_version_for_ticker(ticker: str, safe_kwargs: dict[str, object]) -> 
     """Look up VERSION for an already-resolved (series-only) ticker and append V suffix.
 
     If ``VERSION > 1``, returns the ticker with a separate version token
-    inserted after the series token (e.g. ``S44`` → ``S44 V2``).  Otherwise
+    inserted after the series token (e.g. ``S44`` -> ``S44 V2``).  Otherwise
     returns *ticker* unchanged.
     """
     from xbbg.api.reference import bdp
@@ -233,7 +233,7 @@ def _append_version_to_ticker(ticker: str, version: int) -> str:
     """Insert ``V{version}`` as a separate token after the series token.
 
     Bloomberg expects version as its own space-separated token:
-    ``CDX HY CDSI S44 5Y Corp`` → ``CDX HY CDSI S44 V2 5Y Corp``.
+    ``CDX HY CDSI S44 5Y Corp`` -> ``CDX HY CDSI S44 V2 5Y Corp``.
 
     If the ticker already has a version token (``V{n}``), it is replaced.
 
@@ -308,7 +308,7 @@ def active_cdx(
     1. Call :func:`cdx_ticker` to get the on-the-run series (with version).
     2. Derive the previous-series candidate (``S{n-1}``), then look up its
        ``VERSION`` to build the full versioned ticker.
-    3. If *dt* is before the current series' accrual start → return previous.
+    3. If *dt* is before the current series' accrual start -> return previous.
     4. Otherwise compare ``PX_LAST`` availability over *lookback_days* and
        return whichever series traded most recently.
 
@@ -353,11 +353,11 @@ def active_cdx(
             parts[idx] = f"S{s - 1}"
             prev = " ".join(parts)
 
-    # If no prev candidate, current is series 1 — nothing to compare
+    # If no prev candidate, current is series 1 -- nothing to compare
     if not prev:
         return cur
 
-    # Resolve version for the previous series (e.g. S44 → S44 V2 for CDX HY)
+    # Resolve version for the previous series (e.g. S44 -> S44 V2 for CDX HY)
     prev = _resolve_version_for_ticker(prev, safe_kwargs)
 
     # If dt is before accrual start of current series, prefer previous
@@ -615,7 +615,7 @@ def cdx_defaults(
         )
     except Exception as e:
         logger.warning("Failed to fetch default information for %s: %s", ticker, e)
-        # Return empty via bdp fallback — guarantees consistent return type
+        # Return empty via bdp fallback -- guarantees consistent return type
         from xbbg.api.reference import bdp
 
         return bdp(

--- a/xbbg/ext/cdx.py
+++ b/xbbg/ext/cdx.py
@@ -22,7 +22,28 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["cdx_ticker", "active_cdx"]
+__all__ = [
+    "cdx_ticker",
+    "active_cdx",
+    "cdx_info",
+    "cdx_defaults",
+    "cdx_pricing",
+    "cdx_risk",
+    "cdx_basis",
+    "cdx_default_prob",
+    "cdx_cashflows",
+    "cdx_curve",
+]
+
+# Bloomberg field mnemonics for CDX resolution (canonical uppercase).
+# ReferenceTransformer lowercases field values in SEMI_LONG output,
+# so comparisons below use the lowercase forms.
+_FLD_ROLLING_SERIES = "ROLLING_SERIES"
+_FLD_OTR_INDICATOR = "ON_THE_RUN_CURRENT_BD_INDICATOR"
+_FLD_ACCRUAL_START = "CDS_FIRST_ACCRUAL_START_DATE"
+_FLD_VERSION = "VERSION"
+
+_CDX_FIELDS: list[str] = [_FLD_ROLLING_SERIES, _FLD_OTR_INDICATOR, _FLD_ACCRUAL_START, _FLD_VERSION]
 
 
 def cdx_ticker(
@@ -31,22 +52,30 @@ def cdx_ticker(
     ctx: BloombergContext | None = None,
     **kwargs,
 ) -> str:
-    """Resolve generic CDX 5Y ticker (e.g., 'CDX IG CDSI GEN 5Y Corp') to concrete series.
+    """Resolve generic CDX ticker (e.g., 'CDX IG CDSI GEN 5Y Corp') to concrete series.
 
-    Uses Bloomberg fields:
-      - rolling_series: returns current on-the-run series number
-      - on_the_run_current_bd_indicator: 'Y' if on-the-run
-      - cds_first_accrual_start_date: start date of current series trading
+    Uses Bloomberg fields (via ``bdp`` with ``SEMI_LONG`` format):
+
+    * ``ROLLING_SERIES`` – current on-the-run series number
+    * ``VERSION`` – current version (increments on credit events, e.g. CDX HY)
+    * ``ON_THE_RUN_CURRENT_BD_INDICATOR`` – ``'Y'`` if on-the-run
+    * ``CDS_FIRST_ACCRUAL_START_DATE`` – start date of current series trading
+
+    Version handling:
+        When ``VERSION > 1`` (credit events have occurred, common for CDX HY),
+        a separate version token is inserted: ``S45`` → ``S45 V2``.  When
+        ``VERSION == 1`` (no defaults, typical for CDX IG) the ticker is left
+        as ``S45`` since Bloomberg treats ``S45`` and ``S45 V1`` identically.
 
     Args:
-        gen_ticker: Generic CDX ticker.
+        gen_ticker: Generic CDX ticker containing ``GEN`` token.
         dt: Date to resolve for.
         ctx: Bloomberg context (infrastructure kwargs only). If None, will be
             extracted from kwargs for backward compatibility.
         **kwargs: Legacy kwargs support. If ctx is provided, kwargs are ignored.
 
     Returns:
-        Resolved ticker string.
+        Resolved ticker string, or ``""`` on failure.
     """
     from xbbg.api.reference import bdp
     from xbbg.core.domain.context import split_kwargs
@@ -64,7 +93,7 @@ def cdx_ticker(
     try:
         info = bdp(
             tickers=gen_ticker,
-            flds=["rolling_series", "on_the_run_current_bd_indicator", "cds_first_accrual_start_date"],
+            flds=_CDX_FIELDS,
             backend=Backend.NARWHALS,
             format=Format.SEMI_LONG,
             **safe_kwargs,
@@ -74,43 +103,27 @@ def cdx_ticker(
         return ""
 
     if is_empty(info):
-        logger.warning("No rolling series configuration found for CDX ticker: %s", gen_ticker)
+        logger.warning("No data returned from Bloomberg for CDX ticker: %s", gen_ticker)
         return ""
 
-    # Convert to narwhals if needed and get columns
+    # bdp SEMI_LONG returns columns: ticker, field, value (one row per field).
+    # ReferenceTransformer already lowercases field values.
     nw_info = nw.from_native(info, eager_only=True)
-    columns = nw_info.columns
 
-    if "rolling_series" not in columns:
-        logger.warning("No rolling series configuration found for CDX ticker: %s", gen_ticker)
-        return ""
-
-    # Get data for the ticker - build field lookup from SEMI_LONG format
-    # bdp SEMI_LONG returns: ticker, field, value (one row per field)
-    series = None
-    start_dt = None
-    faccr_col = "cds_first_accrual_start_date"
-
-    # Filter for the target ticker and extract field values using vectorized operations
+    # Filter for the target ticker
     ticker_data = nw_info.filter(nw.col("ticker") == gen_ticker)
 
-    # Extract rolling_series value
-    series_rows = ticker_data.filter(nw.col("field").str.to_lowercase() == "rolling_series").select("value")
+    # --- Validate on-the-run indicator ---
+    otr = _extract_field_value(ticker_data, _FLD_OTR_INDICATOR.lower())
+    if otr is not None and str(otr).upper() != "Y":
+        logger.warning(
+            "Generic ticker %s has ON_THE_RUN_CURRENT_BD_INDICATOR=%r (expected 'Y'); resolution may be stale",
+            gen_ticker,
+            otr,
+        )
 
-    if series_rows.shape[0] > 0:
-        series = series_rows.item(0, 0)
-
-    # Extract cds_first_accrual_start_date value
-    start_dt_rows = ticker_data.filter(nw.col("field").str.to_lowercase() == faccr_col.lower()).select("value")
-
-    if start_dt_rows.shape[0] > 0:
-        start_dt_val = start_dt_rows.item(0, 0)
-        if start_dt_val is not None:
-            try:
-                start_dt = _parse_date(start_dt_val)
-            except (ValueError, TypeError):
-                start_dt = None
-
+    # --- Extract series ---
+    series = _extract_field_value(ticker_data, _FLD_ROLLING_SERIES.lower())
     if series is None:
         logger.warning("No rolling series found for CDX ticker: %s", gen_ticker)
         return ""
@@ -118,19 +131,167 @@ def cdx_ticker(
     with contextlib.suppress(ValueError, TypeError):
         series = int(series)
 
+    # --- Extract version (credit-event counter) ---
+    version: int | None = None
+    version_raw = _extract_field_value(ticker_data, _FLD_VERSION.lower())
+    if version_raw is not None:
+        with contextlib.suppress(ValueError, TypeError):
+            version = int(version_raw)
+
+    # --- Extract accrual start date (for date-based fallback) ---
+    start_dt = None
+    start_dt_raw = _extract_field_value(ticker_data, _FLD_ACCRUAL_START.lower())
+    if start_dt_raw is not None:
+        with contextlib.suppress(ValueError, TypeError):
+            start_dt = _parse_date(start_dt_raw)
+
+    # --- Build resolved ticker ---
     tokens = gen_ticker.split()
     if "GEN" not in tokens:
         logger.warning("Generic ticker %s does not contain expected GEN token for CDX resolution", gen_ticker)
         return ""
-    tokens[tokens.index("GEN")] = f"S{series}"
+
+    gen_idx = tokens.index("GEN")
+
+    # Build series + version tokens: "S45" alone, or "S45 V2" as two tokens when version > 1.
+    # Bloomberg expects: CDX HY CDSI S44 V1 5Y Corp (version is a separate space-delimited token).
+    tokens[gen_idx] = f"S{series}"
+    if version is not None and version > 1:
+        tokens.insert(gen_idx + 1, f"V{version}")
     resolved = " ".join(tokens)
 
-    # If dt is before first accrual date of current series, use prior series
+    # If dt is before first accrual date of current series, fall back to prior series.
+    # Note: prior-series version is unknown here; we omit it and let the caller
+    # re-resolve if needed (version for off-the-run series may differ).
     if (start_dt is not None) and (dt_parsed < start_dt) and isinstance(series, int) and series > 1:
-        tokens[tokens.index(f"S{series}")] = f"S{series - 1}"
+        # Remove any version token that was inserted after the series token
+        tokens = resolved.split()
+        series_idx = _find_series_token_index(tokens)
+        if series_idx is not None:
+            # Remove version token if present right after series
+            if (
+                series_idx + 1 < len(tokens)
+                and tokens[series_idx + 1].startswith("V")
+                and tokens[series_idx + 1][1:].isdigit()
+            ):
+                tokens.pop(series_idx + 1)
+            tokens[series_idx] = f"S{series - 1}"
         resolved = " ".join(tokens)
 
     return resolved
+
+
+def _extract_field_value(ticker_data, field_name: str):
+    """Extract a single field value from SEMI_LONG narwhals frame.
+
+    Args:
+        ticker_data: Narwhals DataFrame already filtered to one ticker,
+            with columns ``ticker``, ``field``, ``value``.
+        field_name: Lowercase field name to look up in the ``field`` column.
+
+    Returns:
+        The scalar value, or ``None`` if not found.
+    """
+    rows = ticker_data.filter(nw.col("field") == field_name).select("value")
+    if rows.shape[0] > 0:
+        return rows.item(0, 0)
+    return None
+
+
+def _resolve_version_for_ticker(ticker: str, safe_kwargs: dict[str, object]) -> str:
+    """Look up VERSION for an already-resolved (series-only) ticker and append V suffix.
+
+    If ``VERSION > 1``, returns the ticker with a separate version token
+    inserted after the series token (e.g. ``S44`` → ``S44 V2``).  Otherwise
+    returns *ticker* unchanged.
+    """
+    from xbbg.api.reference import bdp
+
+    try:
+        meta = bdp(
+            ticker,
+            [_FLD_VERSION],
+            backend=Backend.NARWHALS,
+            format=Format.SEMI_LONG,
+            **safe_kwargs,
+        )
+        if is_empty(meta):
+            return ticker
+        nw_meta = nw.from_native(meta, eager_only=True)
+        td = nw_meta.filter(nw.col("ticker") == ticker)
+        ver_raw = _extract_field_value(td, _FLD_VERSION.lower())
+        if ver_raw is not None:
+            ver = int(ver_raw)
+            if ver > 1:
+                return _append_version_to_ticker(ticker, ver)
+    except Exception:
+        pass
+    return ticker
+
+
+def _append_version_to_ticker(ticker: str, version: int) -> str:
+    """Insert ``V{version}`` as a separate token after the series token.
+
+    Bloomberg expects version as its own space-separated token:
+    ``CDX HY CDSI S44 5Y Corp`` → ``CDX HY CDSI S44 V2 5Y Corp``.
+
+    If the ticker already has a version token (``V{n}``), it is replaced.
+
+    >>> _append_version_to_ticker("CDX HY CDSI S44 5Y Corp", 2)
+    'CDX HY CDSI S44 V2 5Y Corp'
+    """
+    tokens = ticker.split()
+    idx = _find_series_token_index(tokens)
+    if idx is None:
+        return ticker
+
+    # Remove existing version token if present (right after series)
+    if idx + 1 < len(tokens) and tokens[idx + 1].startswith("V") and tokens[idx + 1][1:].isdigit():
+        tokens.pop(idx + 1)
+
+    # Insert version as separate token after series
+    tokens.insert(idx + 1, f"V{version}")
+    return " ".join(tokens)
+
+
+def _parse_series_token(tok: str) -> int | None:
+    """Parse a pure series token like ``S45`` and return the series number.
+
+    Only matches ``S{digits}``.  Does **not** match version tokens like ``V2``.
+    Returns ``None`` if the token is not a series token.
+    """
+    if not tok.startswith("S"):
+        return None
+    rest = tok[1:]
+    if rest.isdigit():
+        return int(rest)
+    return None
+
+
+def _find_series_token_index(tokens: list[str]) -> int | None:
+    """Return the index of the series token (``S{n}``) within *tokens*.
+
+    Returns ``None`` if no series token is found.
+    """
+    for i, tok in enumerate(tokens):
+        if _parse_series_token(tok) is not None:
+            return i
+    return None
+
+
+def _strip_version_from_ticker(ticker: str) -> str:
+    """Remove the version token (``V{n}``) from a resolved CDX ticker.
+
+    >>> _strip_version_from_ticker("CDX HY CDSI S44 V2 5Y Corp")
+    'CDX HY CDSI S44 5Y Corp'
+    """
+    tokens = ticker.split()
+    idx = _find_series_token_index(tokens)
+    if idx is not None and idx + 1 < len(tokens):
+        next_tok = tokens[idx + 1]
+        if next_tok.startswith("V") and next_tok[1:].isdigit():
+            tokens.pop(idx + 1)
+    return " ".join(tokens)
 
 
 def active_cdx(
@@ -140,9 +301,16 @@ def active_cdx(
     ctx: BloombergContext | None = None,
     **kwargs,
 ) -> str:
-    """Choose active CDX series for a date, preferring on-the-run unless it's not started yet.
+    """Choose active CDX series for a date, preferring on-the-run unless it hasn't started yet.
 
-    If ambiguous, prefer the series with recent non-empty PX_LAST over the lookback window.
+    Resolution steps:
+
+    1. Call :func:`cdx_ticker` to get the on-the-run series (with version).
+    2. Derive the previous-series candidate (``S{n-1}``), then look up its
+       ``VERSION`` to build the full versioned ticker.
+    3. If *dt* is before the current series' accrual start → return previous.
+    4. Otherwise compare ``PX_LAST`` availability over *lookback_days* and
+       return whichever series traded most recently.
 
     Args:
         gen_ticker: Generic CDX ticker.
@@ -153,7 +321,7 @@ def active_cdx(
         **kwargs: Legacy kwargs support. If ctx is provided, kwargs are ignored.
 
     Returns:
-        Active ticker string.
+        Active ticker string, or ``""`` on failure.
     """
     from xbbg.api.historical import bdh
     from xbbg.api.reference import bdp
@@ -170,29 +338,33 @@ def active_cdx(
     if not cur:
         return ""
 
-    # Compute previous series candidate
-    parts = cur.split()
-    prev = ""
-    for i, tok in enumerate(parts):
-        if tok.startswith("S") and tok[1:].isdigit():
-            s = int(tok[1:])
-            if s > 1:
-                parts[i] = f"S{s - 1}"
-                prev = " ".join(parts)
-            break
-
-    # If no prev candidate, return current
-    if not prev:
-        return cur
-
     # Convert context to kwargs for bdp/bdh calls
     safe_kwargs = ctx.to_kwargs()
 
-    # If dt is before accrual start, prefer prev
+    # Compute previous series candidate (version-aware).
+    # Strip version token first (prior series has its own version), then decrement series.
+    prev = ""
+    prev_base = _strip_version_from_ticker(cur)
+    parts = prev_base.split()
+    idx = _find_series_token_index(parts)
+    if idx is not None:
+        s = _parse_series_token(parts[idx])
+        if s is not None and s > 1:
+            parts[idx] = f"S{s - 1}"
+            prev = " ".join(parts)
+
+    # If no prev candidate, current is series 1 — nothing to compare
+    if not prev:
+        return cur
+
+    # Resolve version for the previous series (e.g. S44 → S44 V2 for CDX HY)
+    prev = _resolve_version_for_ticker(prev, safe_kwargs)
+
+    # If dt is before accrual start of current series, prefer previous
     try:
         cur_meta = bdp(
             cur,
-            ["cds_first_accrual_start_date"],
+            [_FLD_ACCRUAL_START],
             backend=Backend.NARWHALS,
             format=Format.SEMI_LONG,
             **safe_kwargs,
@@ -200,10 +372,8 @@ def active_cdx(
         cur_start = None
         if not is_empty(cur_meta):
             nw_meta = nw.from_native(cur_meta, eager_only=True)
-            # Extract first non-null value using vectorized filter
-            meta_values = nw_meta.filter(~nw.col("value").is_null()).select("value")
-            if meta_values.shape[0] > 0:
-                val = meta_values.item(0, 0)
+            val = _extract_field_value(nw_meta, _FLD_ACCRUAL_START.lower())
+            if val is not None:
                 with contextlib.suppress(ValueError, TypeError):
                     cur_start = _parse_date(val)
     except Exception:
@@ -212,7 +382,7 @@ def active_cdx(
     if (cur_start is not None) and (dt_parsed < cur_start):
         return prev
 
-    # Otherwise, pick one with recent activity (PX_LAST availability)
+    # Otherwise, pick whichever series has the most recent PX_LAST
     end_date = dt_parsed
     start_date = dt_parsed - timedelta(days=lookback_days)
 
@@ -229,13 +399,12 @@ def active_cdx(
         if is_empty(px):
             return cur
 
-        # Find ticker with most recent non-null PX_LAST value using vectorized operations
         nw_px = nw.from_native(px, eager_only=True)
 
         # Normalize column name (handle both PX_LAST and px_last)
         px_col = "PX_LAST" if "PX_LAST" in nw_px.columns else "px_last"
 
-        # Filter for non-null prices and group by ticker to get max date
+        # Find ticker with most recent non-null PX_LAST
         ticker_latest = (
             nw_px.filter(~nw.col(px_col).is_null()).group_by("ticker").agg(nw.col("date").max().alias("latest_date"))
         )
@@ -243,7 +412,6 @@ def active_cdx(
         if ticker_latest.shape[0] == 0:
             return cur
 
-        # Convert to dict for comparison
         latest_dates: dict[str, str] = {}
         for row in ticker_latest.iter_rows(named=True):
             ticker = row.get("ticker")
@@ -251,7 +419,6 @@ def active_cdx(
             if ticker and date_val:
                 latest_dates[ticker] = str(date_val)
 
-        # Find ticker with most recent date
         best_ticker = cur
         best_date = latest_dates.get(cur, "")
 
@@ -262,3 +429,491 @@ def active_cdx(
 
     except Exception:
         return cur
+
+
+# ---------------------------------------------------------------------------
+# CDX metadata & defaults
+# ---------------------------------------------------------------------------
+
+# Additional Bloomberg fields for cdx_info
+_FLD_NAME = "NAME"
+_FLD_NUM_CURRENT = "NUM_CURRENT_COMPANIES_CCY_TKR"
+_FLD_NUM_ORIG = "NUM_ORIG_COMPANIES_CRNCY_TKR"
+_FLD_PX_LAST = "PX_LAST"
+
+_CDX_INFO_FIELDS: list[str] = [
+    _FLD_ROLLING_SERIES,
+    _FLD_VERSION,
+    _FLD_OTR_INDICATOR,
+    _FLD_ACCRUAL_START,
+    _FLD_NAME,
+    _FLD_NUM_CURRENT,
+    _FLD_NUM_ORIG,
+    _FLD_PX_LAST,
+]
+
+# Pricing fields
+_FLD_PX_BID = "PX_BID"
+_FLD_PX_ASK = "PX_ASK"
+_FLD_UPFRONT_LAST = "UPFRONT_LAST"
+_FLD_UPFRONT_BID = "UPFRONT_BID"
+_FLD_UPFRONT_ASK = "UPFRONT_ASK"
+_FLD_CDS_FLAT_SPREAD = "CDS_FLAT_SPREAD"
+_FLD_UPFRONT_FEE = "UPFRONT_FEE"
+_FLD_PV_CDS_PREMIUM_LEG = "PV_CDS_PREMIUM_LEG"
+_FLD_PV_CDS_DEFAULT_LEG = "PV_CDS_DEFAULT_LEG"
+
+_CDX_PRICING_FIELDS: list[str] = [
+    _FLD_PX_LAST,
+    _FLD_PX_BID,
+    _FLD_PX_ASK,
+    _FLD_UPFRONT_LAST,
+    _FLD_UPFRONT_BID,
+    _FLD_UPFRONT_ASK,
+    _FLD_CDS_FLAT_SPREAD,
+    _FLD_UPFRONT_FEE,
+    _FLD_PV_CDS_PREMIUM_LEG,
+    _FLD_PV_CDS_DEFAULT_LEG,
+]
+
+# Risk fields
+_FLD_SW_CNV_BPV = "SW_CNV_BPV"
+_FLD_SW_EQV_BPV = "SW_EQV_BPV"
+_FLD_CDS_SPREAD_MID_MODIFIED_DURATION = "CDS_SPREAD_MID_MODIFIED_DURATION"
+_FLD_CDS_SPREAD_MID_CONVEXITY = "CDS_SPREAD_MID_CONVEXITY"
+_FLD_RECOVERY_RATE_SEN = "RECOVERY_RATE_SEN"
+_FLD_CDS_RECOVERY_RT = "CDS_RECOVERY_RT"
+
+_CDX_RISK_FIELDS: list[str] = [
+    _FLD_SW_CNV_BPV,
+    _FLD_SW_EQV_BPV,
+    _FLD_CDS_SPREAD_MID_MODIFIED_DURATION,
+    _FLD_CDS_SPREAD_MID_CONVEXITY,
+    _FLD_RECOVERY_RATE_SEN,
+    _FLD_CDS_RECOVERY_RT,
+]
+
+# Basis fields
+_FLD_CDS_INDEX_INTRINSIC_VALUE = "CDS_INDEX_INTRINSIC_VALUE"
+_FLD_CDS_INDEX_INTRINSIC_BASIS_VALUE = "CDS_INDEX_INTRINSIC_BASIS_VALUE"
+_FLD_CDS_IDX_DUR_BASED_INTRINSIC_VAL = "CDS_IDX_DUR_BASED_INTRINSIC_VAL"
+_FLD_CDS_INDEX_DUR_BASED_BASIS_VAL = "CDS_INDEX_DUR_BASED_BASIS_VAL"
+
+_CDX_BASIS_FIELDS: list[str] = [
+    _FLD_CDS_INDEX_INTRINSIC_VALUE,
+    _FLD_CDS_INDEX_INTRINSIC_BASIS_VALUE,
+    _FLD_CDS_IDX_DUR_BASED_INTRINSIC_VAL,
+    _FLD_CDS_INDEX_DUR_BASED_BASIS_VAL,
+    _FLD_PX_LAST,
+]
+
+# Default probability and cashflow fields
+_FLD_CDS_DEFAULT_PROB = "CDS_DEFAULT_PROB"
+_FLD_CASHFLOW_SCHEDULE = "CASHFLOW_SCHEDULE"
+
+# Curve fields
+_FLD_CURRENT_TENOR = "CURRENT_TENOR"
+
+_CDX_CURVE_FIELDS: list[str] = [
+    _FLD_PX_LAST,
+    _FLD_UPFRONT_LAST,
+    _FLD_CDS_FLAT_SPREAD,
+    _FLD_SW_CNV_BPV,
+    _FLD_CURRENT_TENOR,
+]
+
+_CDX_COMMON_TENORS: list[str] = ["1Y", "2Y", "3Y", "4Y", "5Y", "7Y", "10Y", "15Y", "20Y", "30Y"]
+_CDX_CURVE_DEFAULT_TENORS: list[str] = ["3Y", "5Y", "7Y", "10Y"]
+
+
+def cdx_info(
+    ticker: str,
+    *,
+    backend: Backend | None = None,
+    ctx: BloombergContext | None = None,
+    **kwargs,
+):
+    """Return key metadata for a CDX ticker in a single ``bdp`` call.
+
+    Works with both generic (``CDX IG CDSI GEN 5Y Corp``) and resolved
+    (``CDX HY CDSI S45 V2 5Y Corp``) tickers.
+
+    Fields returned (SEMI_LONG rows):
+
+    * ``ROLLING_SERIES``, ``VERSION``, ``ON_THE_RUN_CURRENT_BD_INDICATOR``
+    * ``CDS_FIRST_ACCRUAL_START_DATE``
+    * ``NAME``, ``NUM_CURRENT_COMPANIES_CCY_TKR``, ``NUM_ORIG_COMPANIES_CRNCY_TKR``
+    * ``PX_LAST``
+
+    Args:
+        ticker: Any CDX ticker (generic or resolved).
+        backend: Output backend. If ``None``, uses the global default.
+        ctx: Bloomberg context. If ``None``, extracted from *kwargs*.
+        **kwargs: Legacy kwargs support.
+
+    Returns:
+        DataFrame in the requested backend format (default SEMI_LONG).
+    """
+    from xbbg.api.reference import bdp
+    from xbbg.core.domain.context import split_kwargs
+
+    if ctx is None:
+        split = split_kwargs(**kwargs)
+        ctx = split.infra
+
+    safe_kwargs = ctx.to_kwargs()
+    return bdp(
+        tickers=ticker,
+        flds=_CDX_INFO_FIELDS,
+        backend=backend or Backend.NARWHALS,
+        format=Format.SEMI_LONG,
+        **safe_kwargs,
+    )
+
+
+def cdx_defaults(
+    ticker: str,
+    *,
+    backend: Backend | None = None,
+    ctx: BloombergContext | None = None,
+    **kwargs,
+):
+    """Return credit-event (default) history for a CDX series.
+
+    Wraps the ``CDS_INDEX_DEFAULT_INFORMATION`` bulk field via ``bds``.
+    Returns one row per default with columns including ``company_name``,
+    ``event_date``, ``cds_recovery_rate``, ``auction_date``, and
+    ``previous_weight``.
+
+    An empty frame is returned for series with no defaults (e.g. CDX IG).
+
+    Args:
+        ticker: Resolved CDX ticker (e.g. ``CDX HY CDSI S45 V2 5Y Corp``).
+            Also works without the version token.
+        backend: Output backend. If ``None``, uses the global default.
+        ctx: Bloomberg context. If ``None``, extracted from *kwargs*.
+        **kwargs: Legacy kwargs support.
+
+    Returns:
+        DataFrame with default information (empty if no defaults).
+    """
+    from xbbg.api.reference.reference import bds
+    from xbbg.core.domain.context import split_kwargs
+
+    if ctx is None:
+        split = split_kwargs(**kwargs)
+        ctx = split.infra
+
+    safe_kwargs = ctx.to_kwargs()
+    try:
+        return bds(
+            ticker,
+            "CDS_INDEX_DEFAULT_INFORMATION",
+            backend=backend or Backend.NARWHALS,
+            format=Format.SEMI_LONG,
+            **safe_kwargs,
+        )
+    except Exception as e:
+        logger.warning("Failed to fetch default information for %s: %s", ticker, e)
+        # Return empty via bdp fallback — guarantees consistent return type
+        from xbbg.api.reference import bdp
+
+        return bdp(
+            tickers=ticker,
+            flds=["NAME"],
+            backend=backend or Backend.NARWHALS,
+            format=Format.SEMI_LONG,
+            **safe_kwargs,
+        )
+
+
+def cdx_pricing(
+    ticker: str,
+    *,
+    recovery_rate: float | None = None,
+    backend: Backend | None = None,
+    ctx: BloombergContext | None = None,
+    **kwargs,
+):
+    """Return CDX pricing and valuation analytics in one ``bdp`` call.
+
+    Fields returned (SEMI_LONG rows):
+
+    * ``PX_LAST``, ``PX_BID``, ``PX_ASK``
+    * ``UPFRONT_LAST``, ``UPFRONT_BID``, ``UPFRONT_ASK``
+    * ``CDS_FLAT_SPREAD``
+    * ``UPFRONT_FEE``
+    * ``PV_CDS_PREMIUM_LEG``, ``PV_CDS_DEFAULT_LEG``
+
+    Args:
+        ticker: CDX ticker (generic or resolved).
+        recovery_rate: Recovery-rate override as a decimal (e.g. ``0.30``
+            for 30%).  Mapped to the ``CDS_RR`` Bloomberg override.
+        backend: Output backend. If ``None``, uses the global default.
+        ctx: Bloomberg context. If ``None``, extracted from *kwargs*.
+        **kwargs: Additional Bloomberg overrides (kwargs override named params).
+
+    Returns:
+        DataFrame with CDX pricing analytics.
+    """
+    from xbbg.api.reference import bdp
+    from xbbg.core.domain.context import split_kwargs
+
+    if ctx is None:
+        split = split_kwargs(**kwargs)
+        ctx = split.infra
+
+    safe_kwargs = ctx.to_kwargs()
+
+    overrides: dict[str, object] = {}
+    if recovery_rate is not None:
+        overrides["CDS_RR"] = recovery_rate
+    overrides.update(kwargs)
+
+    call_kwargs = {**safe_kwargs, **overrides}
+    return bdp(
+        tickers=ticker,
+        flds=_CDX_PRICING_FIELDS,
+        backend=backend or Backend.NARWHALS,
+        format=Format.SEMI_LONG,
+        **call_kwargs,
+    )
+
+
+def cdx_risk(
+    ticker: str,
+    *,
+    recovery_rate: float | None = None,
+    backend: Backend | None = None,
+    ctx: BloombergContext | None = None,
+    **kwargs,
+):
+    """Return CDX risk analytics in one ``bdp`` call.
+
+    Fields returned (SEMI_LONG rows):
+
+    * ``SW_CNV_BPV`` (conventional DV01)
+    * ``SW_EQV_BPV`` (equivalent DV01)
+    * ``CDS_SPREAD_MID_MODIFIED_DURATION``
+    * ``CDS_SPREAD_MID_CONVEXITY``
+    * ``RECOVERY_RATE_SEN``
+    * ``CDS_RECOVERY_RT``
+
+    Args:
+        ticker: CDX ticker (generic or resolved).
+        recovery_rate: Recovery-rate override as a decimal (e.g. ``0.30``
+            for 30%).  Mapped to the ``CDS_RR`` Bloomberg override.
+        backend: Output backend. If ``None``, uses the global default.
+        ctx: Bloomberg context. If ``None``, extracted from *kwargs*.
+        **kwargs: Additional Bloomberg overrides (kwargs override named params).
+
+    Returns:
+        DataFrame with CDX risk analytics.
+    """
+    from xbbg.api.reference import bdp
+    from xbbg.core.domain.context import split_kwargs
+
+    if ctx is None:
+        split = split_kwargs(**kwargs)
+        ctx = split.infra
+
+    safe_kwargs = ctx.to_kwargs()
+
+    overrides: dict[str, object] = {}
+    if recovery_rate is not None:
+        overrides["CDS_RR"] = recovery_rate
+    overrides.update(kwargs)
+
+    call_kwargs = {**safe_kwargs, **overrides}
+    return bdp(
+        tickers=ticker,
+        flds=_CDX_RISK_FIELDS,
+        backend=backend or Backend.NARWHALS,
+        format=Format.SEMI_LONG,
+        **call_kwargs,
+    )
+
+
+def cdx_basis(
+    ticker: str,
+    *,
+    backend: Backend | None = None,
+    ctx: BloombergContext | None = None,
+    **kwargs,
+):
+    """Return CDX intrinsic value and basis analytics via ``bdp``.
+
+    Fields returned (SEMI_LONG rows):
+
+    * ``CDS_INDEX_INTRINSIC_VALUE``
+    * ``CDS_INDEX_INTRINSIC_BASIS_VALUE``
+    * ``CDS_IDX_DUR_BASED_INTRINSIC_VAL``
+    * ``CDS_INDEX_DUR_BASED_BASIS_VAL``
+    * ``PX_LAST``
+
+    Args:
+        ticker: CDX ticker (generic or resolved).
+        backend: Output backend. If ``None``, uses the global default.
+        ctx: Bloomberg context. If ``None``, extracted from *kwargs*.
+        **kwargs: Additional Bloomberg overrides.
+
+    Returns:
+        DataFrame with CDX basis analytics.
+    """
+    from xbbg.api.reference import bdp
+    from xbbg.core.domain.context import split_kwargs
+
+    if ctx is None:
+        split = split_kwargs(**kwargs)
+        ctx = split.infra
+
+    safe_kwargs = ctx.to_kwargs()
+    call_kwargs = {**safe_kwargs, **kwargs}
+    return bdp(
+        tickers=ticker,
+        flds=_CDX_BASIS_FIELDS,
+        backend=backend or Backend.NARWHALS,
+        format=Format.SEMI_LONG,
+        **call_kwargs,
+    )
+
+
+def cdx_default_prob(
+    ticker: str,
+    *,
+    backend: Backend | None = None,
+    ctx: BloombergContext | None = None,
+    **kwargs,
+):
+    """Return CDX default-probability term structure via ``bds``.
+
+    Wraps the ``CDS_DEFAULT_PROB`` bulk field and returns term-structure rows,
+    including tenor dates and cumulative default probabilities.
+
+    Args:
+        ticker: CDX ticker (generic or resolved).
+        backend: Output backend. If ``None``, uses the global default.
+        ctx: Bloomberg context. If ``None``, extracted from *kwargs*.
+        **kwargs: Additional Bloomberg overrides.
+
+    Returns:
+        DataFrame with default-probability term structure.
+    """
+    from xbbg.api.reference.reference import bds
+    from xbbg.core.domain.context import split_kwargs
+
+    if ctx is None:
+        split = split_kwargs(**kwargs)
+        ctx = split.infra
+
+    safe_kwargs = ctx.to_kwargs()
+    call_kwargs = {**safe_kwargs, **kwargs}
+    return bds(
+        ticker,
+        _FLD_CDS_DEFAULT_PROB,
+        backend=backend or Backend.NARWHALS,
+        format=Format.SEMI_LONG,
+        **call_kwargs,
+    )
+
+
+def cdx_cashflows(
+    ticker: str,
+    *,
+    backend: Backend | None = None,
+    ctx: BloombergContext | None = None,
+    **kwargs,
+):
+    """Return CDX cashflow schedule via ``bds``.
+
+    Wraps the ``CASHFLOW_SCHEDULE`` bulk field and returns projected coupon and
+    accrual cashflows with associated schedule analytics.
+
+    Args:
+        ticker: CDX ticker (generic or resolved).
+        backend: Output backend. If ``None``, uses the global default.
+        ctx: Bloomberg context. If ``None``, extracted from *kwargs*.
+        **kwargs: Additional Bloomberg overrides.
+
+    Returns:
+        DataFrame with cashflow schedule information.
+    """
+    from xbbg.api.reference.reference import bds
+    from xbbg.core.domain.context import split_kwargs
+
+    if ctx is None:
+        split = split_kwargs(**kwargs)
+        ctx = split.infra
+
+    safe_kwargs = ctx.to_kwargs()
+    call_kwargs = {**safe_kwargs, **kwargs}
+    return bds(
+        ticker,
+        _FLD_CASHFLOW_SCHEDULE,
+        backend=backend or Backend.NARWHALS,
+        format=Format.SEMI_LONG,
+        **call_kwargs,
+    )
+
+
+def cdx_curve(
+    gen_ticker: str,
+    tenors: list[str] | None = None,
+    *,
+    backend: Backend | None = None,
+    ctx: BloombergContext | None = None,
+    **kwargs,
+):
+    """Return a CDX tenor curve by querying multiple tenor tickers in one ``bdp`` call.
+
+    The function replaces the tenor token in *gen_ticker* across *tenors* and
+    fetches curve analytics for each resulting ticker.
+
+    Args:
+        gen_ticker: Generic CDX ticker with a tenor token (e.g. ``5Y``).
+        tenors: Tenors to query. Defaults to ``["3Y", "5Y", "7Y", "10Y"]``.
+        backend: Output backend. If ``None``, uses the global default.
+        ctx: Bloomberg context. If ``None``, extracted from *kwargs*.
+        **kwargs: Additional Bloomberg overrides.
+
+    Returns:
+        DataFrame combining curve analytics across all requested tenors.
+    """
+    from xbbg.api.reference import bdp
+    from xbbg.core.domain.context import split_kwargs
+
+    if ctx is None:
+        split = split_kwargs(**kwargs)
+        ctx = split.infra
+
+    safe_kwargs = ctx.to_kwargs()
+    call_kwargs = {**safe_kwargs, **kwargs}
+
+    requested_tenors = tenors or _CDX_CURVE_DEFAULT_TENORS
+
+    seen_tenors: set[str] = set()
+    normalized_tenors: list[str] = []
+    for tenor in requested_tenors:
+        if tenor not in seen_tenors:
+            normalized_tenors.append(tenor)
+            seen_tenors.add(tenor)
+
+    tokens = gen_ticker.split()
+    tenor_idx = next((idx for idx, tok in enumerate(tokens) if tok in _CDX_COMMON_TENORS), None)
+
+    if tenor_idx is None:
+        curve_tickers = [gen_ticker]
+    else:
+        curve_tickers = []
+        for tenor in normalized_tenors:
+            tenor_tokens = list(tokens)
+            tenor_tokens[tenor_idx] = tenor
+            curve_tickers.append(" ".join(tenor_tokens))
+
+    return bdp(
+        tickers=curve_tickers,
+        flds=_CDX_CURVE_FIELDS,
+        backend=backend or Backend.NARWHALS,
+        format=Format.SEMI_LONG,
+        **call_kwargs,
+    )

--- a/xbbg/ext/options.py
+++ b/xbbg/ext/options.py
@@ -18,8 +18,18 @@ module are explicit constants so users can quickly inspect the supported scope.
 from __future__ import annotations
 
 from datetime import datetime
-from enum import StrEnum
 import logging
+import sys
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+    from enum import Enum
+
+    class StrEnum(str, Enum):
+        """Polyfill for Python <3.11."""
+
+
 from typing import TYPE_CHECKING
 
 from xbbg.backend import Backend, Format

--- a/xbbg/ext/options.py
+++ b/xbbg/ext/options.py
@@ -504,7 +504,6 @@ def option_chain(
     * ``expiry_match`` -> ``CHAIN_EXP_MATCH_OVRD``
 
     Notes:
-
     * ``expiry_dt`` is normalized to ``YYYYMMDD`` when parseable.
     * ``strike`` accepts ``StrikeRef.ATM`` / ``"ATM"`` or a numeric strike.
     * Any explicit ``kwargs`` values take precedence over named parameters.
@@ -640,7 +639,6 @@ def option_chain_bql(
         open_int(), px_last(), px_bid(), px_ask()
 
     Notes:
-
     * Date values use ISO format (``YYYY-MM-DD``) in BQL predicates.
     * ``extra_filters`` allows arbitrary BQL syntax for advanced use cases
       (e.g. ``"theta().value>=-0.5"``).

--- a/xbbg/ext/options.py
+++ b/xbbg/ext/options.py
@@ -1,0 +1,838 @@
+"""Bloomberg Options Analytics API.
+
+This module provides convenience functions for equity option analytics including
+option metadata, Greeks, pricing, option chain retrieval with filtering, and
+multi-option comparison.
+
+The functions mirror the API patterns used across ``xbbg.ext`` modules:
+
+* Lazy imports for Bloomberg request functions.
+* Context extraction via ``split_kwargs`` for compatibility.
+* Default output to ``Backend.NARWHALS`` and ``Format.SEMI_LONG``.
+* Named parameters for commonly-used overrides.
+
+All Bloomberg field mnemonics and ``CHAIN_TICKERS`` override names in this
+module are explicit constants so users can quickly inspect the supported scope.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+import logging
+from typing import TYPE_CHECKING
+
+from xbbg.backend import Backend, Format
+
+if TYPE_CHECKING:
+    from xbbg.core.domain.context import BloombergContext
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    # Enums
+    "PutCall",
+    "ChainPeriodicity",
+    "StrikeRef",
+    "ExerciseType",
+    "ExpiryMatch",
+    # Functions
+    "option_info",
+    "option_greeks",
+    "option_pricing",
+    "option_chain",
+    "option_chain_bql",
+    "option_screen",
+]
+
+
+class PutCall(StrEnum):
+    """Put/call filter for CHAIN_PUT_CALL_TYPE_OVRD."""
+
+    CALL = "C"
+    PUT = "P"
+
+
+class ChainPeriodicity(StrEnum):
+    """Expiry periodicity for CHAIN_PERIODICITY_OVRD."""
+
+    WEEKLY = "W"
+    MONTHLY = "M"
+    QUARTERLY = "Q"
+    YEARLY = "Y"
+    ALL = ""
+
+
+class StrikeRef(StrEnum):
+    """Strike reference for CHAIN_STRIKE_PX_OVRD."""
+
+    ATM = "ATM"
+
+
+class ExerciseType(StrEnum):
+    """Exercise type for CHAIN_EXERCISE_TYPE_OVRD."""
+
+    AMERICAN = "A"
+    EUROPEAN = "E"
+
+
+class ExpiryMatch(StrEnum):
+    """Expiry date matching for CHAIN_EXP_MATCH_OVRD."""
+
+    EXACT = "E"
+    CLOSEST = "C"
+
+
+# ---------------------------------------------------------------------------
+# Bloomberg field constants: option metadata
+# ---------------------------------------------------------------------------
+
+_FLD_OPT_STRIKE_PX = "OPT_STRIKE_PX"
+_FLD_OPT_EXPIRE_DT = "OPT_EXPIRE_DT"
+_FLD_OPT_PUT_CALL = "OPT_PUT_CALL"
+_FLD_OPT_EXER_TYP = "OPT_EXER_TYP"
+_FLD_OPT_UNDL_TICKER = "OPT_UNDL_TICKER"
+_FLD_OPT_UNDL_PX = "OPT_UNDL_PX"
+_FLD_OPT_CONT_SIZE = "OPT_CONT_SIZE"
+_FLD_OPT_MULTIPLIER = "OPT_MULTIPLIER"
+_FLD_NAME = "NAME"
+_FLD_SECURITY_DES = "SECURITY_DES"
+
+_OPTION_INFO_FIELDS: list[str] = [
+    _FLD_OPT_STRIKE_PX,
+    _FLD_OPT_EXPIRE_DT,
+    _FLD_OPT_PUT_CALL,
+    _FLD_OPT_EXER_TYP,
+    _FLD_OPT_UNDL_TICKER,
+    _FLD_OPT_UNDL_PX,
+    _FLD_OPT_CONT_SIZE,
+    _FLD_OPT_MULTIPLIER,
+    _FLD_NAME,
+    _FLD_SECURITY_DES,
+]
+
+
+# ---------------------------------------------------------------------------
+# Bloomberg field constants: option Greeks and implied volatility
+# ---------------------------------------------------------------------------
+
+_FLD_DELTA_MID = "DELTA_MID"
+_FLD_GAMMA_MID = "GAMMA_MID"
+_FLD_VEGA_MID = "VEGA_MID"
+_FLD_THETA_MID = "THETA_MID"
+_FLD_RHO_MID = "RHO_MID"
+
+_FLD_DELTA = "DELTA"
+_FLD_DELTA_BID = "DELTA_BID"
+_FLD_DELTA_ASK = "DELTA_ASK"
+_FLD_GAMMA = "GAMMA"
+_FLD_GAMMA_BID = "GAMMA_BID"
+_FLD_GAMMA_ASK = "GAMMA_ASK"
+_FLD_VEGA = "VEGA"
+_FLD_VEGA_BID = "VEGA_BID"
+_FLD_VEGA_ASK = "VEGA_ASK"
+_FLD_THETA_BID = "THETA_BID"
+_FLD_THETA_ASK = "THETA_ASK"
+_FLD_RHO_BID = "RHO_BID"
+_FLD_RHO_ASK = "RHO_ASK"
+
+_FLD_IVOL_MID = "IVOL_MID"
+_FLD_IVOL_BID = "IVOL_BID"
+_FLD_IVOL_ASK = "IVOL_ASK"
+
+_OPTION_GREEKS_FIELDS: list[str] = [
+    _FLD_DELTA_MID,
+    _FLD_GAMMA_MID,
+    _FLD_VEGA_MID,
+    _FLD_THETA_MID,
+    _FLD_RHO_MID,
+    _FLD_DELTA,
+    _FLD_DELTA_BID,
+    _FLD_DELTA_ASK,
+    _FLD_GAMMA,
+    _FLD_GAMMA_BID,
+    _FLD_GAMMA_ASK,
+    _FLD_VEGA,
+    _FLD_VEGA_BID,
+    _FLD_VEGA_ASK,
+    _FLD_THETA_BID,
+    _FLD_THETA_ASK,
+    _FLD_RHO_BID,
+    _FLD_RHO_ASK,
+    _FLD_IVOL_MID,
+    _FLD_IVOL_BID,
+    _FLD_IVOL_ASK,
+]
+
+
+# ---------------------------------------------------------------------------
+# Bloomberg field constants: option pricing and activity
+# ---------------------------------------------------------------------------
+
+_FLD_PX_LAST = "PX_LAST"
+_FLD_PX_BID = "PX_BID"
+_FLD_PX_ASK = "PX_ASK"
+_FLD_OPT_INTRINSIC_VAL = "OPT_INTRINSIC_VAL"
+_FLD_OPT_TRUE_INTRINSIC = "OPT_TRUE_INTRINSIC"
+_FLD_OPT_TIME_VAL = "OPT_TIME_VAL"
+_FLD_OPEN_INT = "OPEN_INT"
+_FLD_PX_VOLUME = "PX_VOLUME"
+_FLD_OPEN_INT_CHANGE = "OPEN_INT_CHANGE"
+
+_OPTION_PRICING_FIELDS: list[str] = [
+    _FLD_PX_LAST,
+    _FLD_PX_BID,
+    _FLD_PX_ASK,
+    _FLD_OPT_INTRINSIC_VAL,
+    _FLD_OPT_TRUE_INTRINSIC,
+    _FLD_OPT_TIME_VAL,
+    _FLD_OPEN_INT,
+    _FLD_PX_VOLUME,
+    _FLD_OPEN_INT_CHANGE,
+]
+
+
+# ---------------------------------------------------------------------------
+# Bloomberg field constants: option chain bulk field and overrides
+# ---------------------------------------------------------------------------
+
+_FLD_CHAIN_TICKERS = "CHAIN_TICKERS"
+
+_OVRD_CHAIN_PUT_CALL_TYPE = "CHAIN_PUT_CALL_TYPE_OVRD"
+_OVRD_CHAIN_EXP_DT = "CHAIN_EXP_DT_OVRD"
+_OVRD_CHAIN_STRIKE_PX = "CHAIN_STRIKE_PX_OVRD"
+_OVRD_CHAIN_POINTS = "CHAIN_POINTS_OVRD"
+_OVRD_CHAIN_PERIODICITY = "CHAIN_PERIODICITY_OVRD"
+_OVRD_CHAIN_EXERCISE_TYPE = "CHAIN_EXERCISE_TYPE_OVRD"
+_OVRD_CHAIN_EXP_MATCH = "CHAIN_EXP_MATCH_OVRD"
+
+
+_OPTION_SCREEN_DEFAULT_FIELDS: list[str] = [
+    _FLD_NAME,
+    _FLD_SECURITY_DES,
+    _FLD_OPT_STRIKE_PX,
+    _FLD_OPT_EXPIRE_DT,
+    _FLD_OPT_PUT_CALL,
+    _FLD_OPT_EXER_TYP,
+    _FLD_OPT_UNDL_TICKER,
+    _FLD_OPT_UNDL_PX,
+    _FLD_PX_LAST,
+    _FLD_PX_BID,
+    _FLD_PX_ASK,
+    _FLD_IVOL_MID,
+    _FLD_DELTA_MID,
+    _FLD_GAMMA_MID,
+    _FLD_VEGA_MID,
+    _FLD_THETA_MID,
+    _FLD_RHO_MID,
+    _FLD_OPEN_INT,
+    _FLD_PX_VOLUME,
+]
+
+
+def _enum_value(value) -> str | int | float:
+    """Return raw enum value for StrEnum-compatible inputs.
+
+    Args:
+        value: Value that may be an enum member or plain scalar.
+
+    Returns:
+        Underlying scalar value to send in Bloomberg overrides.
+    """
+    if isinstance(value, StrEnum):
+        return value.value
+    return value
+
+
+def _format_expiry_dt(expiry_dt: str | None) -> str | None:
+    """Normalize chain expiry override into ``YYYYMMDD`` when possible.
+
+    Bloomberg accepts ``CHAIN_EXP_DT_OVRD`` as text.  This helper mirrors the
+    tolerant date behavior used in other ``xbbg.ext`` modules:
+
+    * If *expiry_dt* is ``None`` -> returns ``None``.
+    * If parseable as an ISO-style date (``YYYY-MM-DD`` / ``YYYY/MM/DD``) ->
+      returns ``YYYYMMDD``.
+    * If parsing fails -> returns the original text unchanged.
+
+    Args:
+        expiry_dt: Requested expiry date override.
+
+    Returns:
+        Formatted date override or original string.
+    """
+    if expiry_dt is None:
+        return None
+
+    try:
+        dt = datetime.fromisoformat(expiry_dt.replace("/", "-"))
+        return f"{dt.year:04d}{dt.month:02d}{dt.day:02d}"
+    except (ValueError, TypeError):
+        return expiry_dt
+
+
+def _format_strike(strike: str | float | None) -> str | None:
+    """Normalize chain strike override.
+
+    ``CHAIN_STRIKE_PX_OVRD`` can be passed as:
+
+    * ``StrikeRef.ATM`` / ``"ATM"`` for at-the-money anchoring.
+    * A numeric value as text (for example ``"600"``).
+    * A float value (for example ``600.0``) which is converted to string.
+
+    Args:
+        strike: Strike selector for chain retrieval.
+
+    Returns:
+        Strike override string or ``None``.
+    """
+    if strike is None:
+        return None
+
+    if isinstance(strike, StrEnum):
+        return strike.value
+
+    if isinstance(strike, str):
+        return strike
+
+    return str(strike)
+
+
+def option_info(
+    ticker: str,
+    *,
+    backend: Backend | None = None,
+    ctx: BloombergContext | None = None,
+    **kwargs,
+):
+    """Return static option reference metadata in one ``bdp`` call.
+
+    Fields returned (SEMI_LONG rows):
+
+    * ``OPT_STRIKE_PX``
+    * ``OPT_EXPIRE_DT``
+    * ``OPT_PUT_CALL``
+    * ``OPT_EXER_TYP``
+    * ``OPT_UNDL_TICKER``
+    * ``OPT_UNDL_PX``
+    * ``OPT_CONT_SIZE``
+    * ``OPT_MULTIPLIER``
+    * ``NAME``
+    * ``SECURITY_DES``
+
+    This function is useful for quickly validating an option contract's static
+    setup before running any pricing or Greeks workflow.  It includes the
+    contract mechanics (strike, expiry, exercise style, multiplier) and links
+    the option to its underlying instrument.
+
+    Args:
+        ticker: Bloomberg option ticker.
+        backend: Output backend. If ``None``, uses ``Backend.NARWHALS``.
+        ctx: Bloomberg context. If ``None``, extracted from *kwargs*.
+        **kwargs: Additional Bloomberg overrides and legacy kwargs support.
+
+    Returns:
+        DataFrame with option reference metadata.
+    """
+    from xbbg.api.reference import bdp
+    from xbbg.core.domain.context import split_kwargs
+
+    if ctx is None:
+        split = split_kwargs(**kwargs)
+        ctx = split.infra
+
+    safe_kwargs = ctx.to_kwargs()
+    call_kwargs = {**safe_kwargs, **kwargs}
+    return bdp(
+        tickers=ticker,
+        flds=_OPTION_INFO_FIELDS,
+        backend=backend or Backend.NARWHALS,
+        format=Format.SEMI_LONG,
+        **call_kwargs,
+    )
+
+
+def option_greeks(
+    ticker: str,
+    *,
+    backend: Backend | None = None,
+    ctx: BloombergContext | None = None,
+    **kwargs,
+):
+    """Return option Greeks and implied volatility in one ``bdp`` call.
+
+    Fields returned (SEMI_LONG rows):
+
+    Mid Greeks:
+
+    * ``DELTA_MID``
+    * ``GAMMA_MID``
+    * ``VEGA_MID``
+    * ``THETA_MID``
+    * ``RHO_MID``
+
+    Bid/ask Greeks:
+
+    * ``DELTA``, ``DELTA_BID``, ``DELTA_ASK``
+    * ``GAMMA``, ``GAMMA_BID``, ``GAMMA_ASK``
+    * ``VEGA``, ``VEGA_BID``, ``VEGA_ASK``
+    * ``THETA_BID``, ``THETA_ASK``
+    * ``RHO_BID``, ``RHO_ASK``
+
+    Implied volatility:
+
+    * ``IVOL_MID``
+    * ``IVOL_BID``
+    * ``IVOL_ASK``
+
+    The output combines model sensitivities and vol marks so users can run both
+    directional and relative-value diagnostics from a single request.
+
+    Args:
+        ticker: Bloomberg option ticker.
+        backend: Output backend. If ``None``, uses ``Backend.NARWHALS``.
+        ctx: Bloomberg context. If ``None``, extracted from *kwargs*.
+        **kwargs: Additional Bloomberg overrides and legacy kwargs support.
+
+    Returns:
+        DataFrame with option Greeks and volatility analytics.
+    """
+    from xbbg.api.reference import bdp
+    from xbbg.core.domain.context import split_kwargs
+
+    if ctx is None:
+        split = split_kwargs(**kwargs)
+        ctx = split.infra
+
+    safe_kwargs = ctx.to_kwargs()
+    call_kwargs = {**safe_kwargs, **kwargs}
+    return bdp(
+        tickers=ticker,
+        flds=_OPTION_GREEKS_FIELDS,
+        backend=backend or Backend.NARWHALS,
+        format=Format.SEMI_LONG,
+        **call_kwargs,
+    )
+
+
+def option_pricing(
+    ticker: str,
+    *,
+    backend: Backend | None = None,
+    ctx: BloombergContext | None = None,
+    **kwargs,
+):
+    """Return option pricing, value decomposition, and activity metrics.
+
+    Fields returned (SEMI_LONG rows):
+
+    Pricing:
+
+    * ``PX_LAST``
+    * ``PX_BID``
+    * ``PX_ASK``
+
+    Intrinsic/time decomposition:
+
+    * ``OPT_INTRINSIC_VAL``
+    * ``OPT_TRUE_INTRINSIC``
+    * ``OPT_TIME_VAL``
+
+    Activity and positioning:
+
+    * ``OPEN_INT``
+    * ``PX_VOLUME``
+    * ``OPEN_INT_CHANGE``
+
+    This function is designed for practical tape-reading workflows that need
+    quote levels, valuation breakdown, and flow context in one table.
+
+    Args:
+        ticker: Bloomberg option ticker.
+        backend: Output backend. If ``None``, uses ``Backend.NARWHALS``.
+        ctx: Bloomberg context. If ``None``, extracted from *kwargs*.
+        **kwargs: Additional Bloomberg overrides and legacy kwargs support.
+
+    Returns:
+        DataFrame with option pricing and activity fields.
+    """
+    from xbbg.api.reference import bdp
+    from xbbg.core.domain.context import split_kwargs
+
+    if ctx is None:
+        split = split_kwargs(**kwargs)
+        ctx = split.infra
+
+    safe_kwargs = ctx.to_kwargs()
+    call_kwargs = {**safe_kwargs, **kwargs}
+    return bdp(
+        tickers=ticker,
+        flds=_OPTION_PRICING_FIELDS,
+        backend=backend or Backend.NARWHALS,
+        format=Format.SEMI_LONG,
+        **call_kwargs,
+    )
+
+
+def option_chain(
+    underlying: str,
+    *,
+    put_call: PutCall | str | None = None,
+    expiry_dt: str | None = None,
+    strike: StrikeRef | str | float | None = None,
+    points: int | None = None,
+    periodicity: ChainPeriodicity | str | None = None,
+    exercise_type: ExerciseType | str | None = None,
+    expiry_match: ExpiryMatch | str | None = None,
+    backend: Backend | None = None,
+    ctx: BloombergContext | None = None,
+    **kwargs,
+):
+    """Return an option chain via ``CHAIN_TICKERS`` bulk field.
+
+    This function wraps Bloomberg ``bds`` with the ``CHAIN_TICKERS`` field and
+    exposes common chain filters as typed named parameters.
+
+    Named parameters map to Bloomberg overrides:
+
+    * ``put_call`` -> ``CHAIN_PUT_CALL_TYPE_OVRD``
+    * ``expiry_dt`` -> ``CHAIN_EXP_DT_OVRD``
+    * ``strike`` -> ``CHAIN_STRIKE_PX_OVRD``
+    * ``points`` -> ``CHAIN_POINTS_OVRD``
+    * ``periodicity`` -> ``CHAIN_PERIODICITY_OVRD``
+    * ``exercise_type`` -> ``CHAIN_EXERCISE_TYPE_OVRD``
+    * ``expiry_match`` -> ``CHAIN_EXP_MATCH_OVRD``
+
+    Notes:
+
+    * ``expiry_dt`` is normalized to ``YYYYMMDD`` when parseable.
+    * ``strike`` accepts ``StrikeRef.ATM`` / ``"ATM"`` or a numeric strike.
+    * Any explicit ``kwargs`` values take precedence over named parameters.
+    * Chain output schema is Bloomberg-defined and may vary by asset class.
+
+    Args:
+        underlying: Underlying ticker used to request chain members.
+        put_call: Put/call selector.
+        expiry_dt: Target expiry date (prefer ``YYYYMMDD``).
+        strike: Strike selector (``ATM`` or specific strike).
+        points: Number of strikes around reference strike.
+        periodicity: Expiry periodicity filter.
+        exercise_type: Exercise-style filter.
+        expiry_match: Expiry matching mode.
+        backend: Output backend. If ``None``, uses ``Backend.NARWHALS``.
+        ctx: Bloomberg context. If ``None``, extracted from *kwargs*.
+        **kwargs: Additional Bloomberg overrides and legacy kwargs support.
+
+    Returns:
+        DataFrame with option chain rows from ``CHAIN_TICKERS``.
+    """
+    from xbbg.api.reference.reference import bds
+    from xbbg.core.domain.context import split_kwargs
+
+    if ctx is None:
+        split = split_kwargs(**kwargs)
+        ctx = split.infra
+
+    safe_kwargs = ctx.to_kwargs()
+
+    overrides: dict[str, object] = {}
+    if put_call is not None:
+        overrides[_OVRD_CHAIN_PUT_CALL_TYPE] = _enum_value(put_call)
+
+    formatted_expiry = _format_expiry_dt(expiry_dt)
+    if formatted_expiry is not None:
+        overrides[_OVRD_CHAIN_EXP_DT] = formatted_expiry
+
+    formatted_strike = _format_strike(strike)
+    if formatted_strike is not None:
+        overrides[_OVRD_CHAIN_STRIKE_PX] = formatted_strike
+
+    if points is not None:
+        overrides[_OVRD_CHAIN_POINTS] = points
+
+    if periodicity is not None:
+        overrides[_OVRD_CHAIN_PERIODICITY] = _enum_value(periodicity)
+
+    if exercise_type is not None:
+        overrides[_OVRD_CHAIN_EXERCISE_TYPE] = _enum_value(exercise_type)
+
+    if expiry_match is not None:
+        overrides[_OVRD_CHAIN_EXP_MATCH] = _enum_value(expiry_match)
+
+    overrides.update(kwargs)
+
+    call_kwargs = {**safe_kwargs, **overrides}
+    return bds(
+        underlying,
+        _FLD_CHAIN_TICKERS,
+        backend=backend or Backend.NARWHALS,
+        format=Format.SEMI_LONG,
+        **call_kwargs,
+    )
+
+
+def option_chain_bql(
+    underlying: str,
+    *,
+    put_call: PutCall | str | None = None,
+    expiry_start: str | None = None,
+    expiry_end: str | None = None,
+    strike_low: float | None = None,
+    strike_high: float | None = None,
+    delta_low: float | None = None,
+    delta_high: float | None = None,
+    gamma_low: float | None = None,
+    gamma_high: float | None = None,
+    vega_low: float | None = None,
+    vega_high: float | None = None,
+    theta_low: float | None = None,
+    theta_high: float | None = None,
+    ivol_low: float | None = None,
+    ivol_high: float | None = None,
+    moneyness_low: float | None = None,
+    moneyness_high: float | None = None,
+    min_open_int: int | None = None,
+    min_volume: int | None = None,
+    min_bid: float | None = None,
+    max_ask: float | None = None,
+    exch_code: str | None = None,
+    exercise_type: ExerciseType | str | None = None,
+    extra_filters: str | None = None,
+    get_fields: list[str] | None = None,
+    backend: Backend | None = None,
+    ctx: BloombergContext | None = None,
+    **kwargs,
+):
+    """Return a filtered option chain via BQL.
+
+    BQL provides richer filtering than ``CHAIN_TICKERS`` overrides: filter by
+    Greeks, implied volatility, open interest, moneyness, bid/ask prices,
+    exchange, and arbitrary combinations.
+
+    Filter parameters map to BQL ``filter()`` predicates on the
+    ``options('<underlying>')`` universe:
+
+    * ``put_call`` -> ``put_call=='Call'`` / ``put_call=='Put'``
+    * ``expiry_start`` / ``expiry_end`` -> ``expire_dt()>=`` / ``expire_dt()<=``
+    * ``strike_low`` / ``strike_high`` -> ``between(strike_px(), low, high)``
+    * ``delta_low`` / ``delta_high`` -> ``delta().value>=`` / ``delta().value<=``
+    * ``gamma_low`` / ``gamma_high`` -> ``gamma().value>=`` / ``gamma().value<=``
+    * ``vega_low`` / ``vega_high`` -> ``vega().value>=`` / ``vega().value<=``
+    * ``theta_low`` / ``theta_high`` -> ``theta().value>=`` / ``theta().value<=``
+    * ``ivol_low`` / ``ivol_high`` -> ``ivol().value>=`` / ``ivol().value<=``
+    * ``moneyness_low`` / ``moneyness_high`` -> ``pct_moneyness().value>=`` / ``<=``
+    * ``min_open_int`` -> ``open_int().value>=``
+    * ``min_volume`` -> ``volume().value>=``
+    * ``min_bid`` -> ``px_bid().value>=``
+    * ``max_ask`` -> ``px_ask().value<=``
+    * ``exch_code`` -> ``exch_code=='<code>'`` (e.g. ``'Z'`` for CBOE)
+    * ``exercise_type`` -> ``exer_typ=='American'`` / ``exer_typ=='European'``
+    * ``extra_filters`` -> appended verbatim (for custom BQL predicates)
+
+    If *get_fields* is not provided, defaults to::
+
+        (
+            strike_px(),
+            expire_dt(),
+            ivol(),
+            delta(),
+        )
+        open_int(), px_last(), px_bid(), px_ask()
+
+    Notes:
+
+    * Date values use ISO format (``YYYY-MM-DD``) in BQL predicates.
+    * ``extra_filters`` allows arbitrary BQL syntax for advanced use cases
+      (e.g. ``"theta().value>=-0.5"``).
+
+    Args:
+        underlying: Underlying ticker (e.g. ``'SPY US Equity'``).
+        put_call: ``'Call'`` or ``'Put'`` (or :class:`PutCall` enum).
+        expiry_start: Earliest expiry date (``YYYY-MM-DD``).
+        expiry_end: Latest expiry date (``YYYY-MM-DD``).
+        strike_low: Minimum strike price.
+        strike_high: Maximum strike price.
+        delta_low: Minimum delta (e.g. ``0.3``).
+        delta_high: Maximum delta (e.g. ``0.7``).
+        gamma_low: Minimum gamma.
+        gamma_high: Maximum gamma.
+        vega_low: Minimum vega.
+        vega_high: Maximum vega.
+        theta_low: Minimum theta (note: theta is typically negative).
+        theta_high: Maximum theta.
+        ivol_low: Minimum implied volatility.
+        ivol_high: Maximum implied volatility.
+        moneyness_low: Minimum percent moneyness (e.g. ``98`` for 2% OTM).
+        moneyness_high: Maximum percent moneyness (e.g. ``102`` for 2% ITM).
+        min_open_int: Minimum open interest.
+        min_volume: Minimum trading volume.
+        min_bid: Minimum bid price (filters illiquid options).
+        max_ask: Maximum ask price.
+        exch_code: Exchange code filter (e.g. ``'Z'`` for CBOE).
+        exercise_type: American or European.
+        extra_filters: Additional BQL filter predicates (appended with ``and``).
+        get_fields: BQL ``get()`` fields.  Defaults to core pricing/greeks.
+        backend: Output backend.
+        ctx: Bloomberg context.
+        **kwargs: Forwarded to ``blp.bql()``.
+
+    Returns:
+        DataFrame with filtered option chain from BQL.
+    """
+    from xbbg.api.screening import bql as _bql
+    from xbbg.core.domain.context import split_kwargs
+
+    if ctx is None:
+        split = split_kwargs(**kwargs)
+        ctx = split.infra
+
+    safe_kwargs = ctx.to_kwargs()
+
+    # Build get fields
+    default_get = [
+        "strike_px()",
+        "expire_dt()",
+        "ivol()",
+        "delta()",
+        "open_int()",
+        "px_last()",
+        "px_bid()",
+        "px_ask()",
+    ]
+    get_list = get_fields or default_get
+    get_clause = ", ".join(get_list)
+
+    # Build filter predicates
+    filters: list[str] = []
+    if put_call is not None:
+        pc_val = "Call" if str(put_call).upper() in ("C", "CALL") else "Put"
+        filters.append(f"put_call=='{pc_val}'")
+
+    if expiry_start is not None:
+        filters.append(f"expire_dt()>='{expiry_start}'")
+    if expiry_end is not None:
+        filters.append(f"expire_dt()<='{expiry_end}'")
+
+    if strike_low is not None and strike_high is not None:
+        filters.append(f"between(strike_px(), {strike_low}, {strike_high})")
+    elif strike_low is not None:
+        filters.append(f"strike_px()>={strike_low}")
+    elif strike_high is not None:
+        filters.append(f"strike_px()<={strike_high}")
+
+    if delta_low is not None:
+        filters.append(f"delta().value>={delta_low}")
+    if delta_high is not None:
+        filters.append(f"delta().value<={delta_high}")
+
+    if gamma_low is not None:
+        filters.append(f"gamma().value>={gamma_low}")
+    if gamma_high is not None:
+        filters.append(f"gamma().value<={gamma_high}")
+
+    if vega_low is not None:
+        filters.append(f"vega().value>={vega_low}")
+    if vega_high is not None:
+        filters.append(f"vega().value<={vega_high}")
+
+    if theta_low is not None:
+        filters.append(f"theta().value>={theta_low}")
+    if theta_high is not None:
+        filters.append(f"theta().value<={theta_high}")
+
+    if ivol_low is not None:
+        filters.append(f"ivol().value>={ivol_low}")
+    if ivol_high is not None:
+        filters.append(f"ivol().value<={ivol_high}")
+
+    if moneyness_low is not None:
+        filters.append(f"pct_moneyness().value>={moneyness_low}")
+    if moneyness_high is not None:
+        filters.append(f"pct_moneyness().value<={moneyness_high}")
+
+    if min_open_int is not None:
+        filters.append(f"open_int().value>={min_open_int}")
+
+    if min_volume is not None:
+        filters.append(f"volume().value>={min_volume}")
+
+    if min_bid is not None:
+        filters.append(f"px_bid().value>={min_bid}")
+    if max_ask is not None:
+        filters.append(f"px_ask().value<={max_ask}")
+
+    if exch_code is not None:
+        filters.append(f"exch_code=='{exch_code}'")
+
+    if exercise_type is not None:
+        ex_val = "American" if str(exercise_type).upper() in ("A", "AMERICAN") else "European"
+        filters.append(f"exer_typ=='{ex_val}'")
+
+    if extra_filters:
+        filters.append(extra_filters)
+
+    # Build universe clause
+    universe = f"options('{underlying}')"
+    if filters:
+        filter_str = " and ".join(filters)
+        for_clause = f"filter({universe}, {filter_str})"
+    else:
+        for_clause = universe
+
+    query = f"get({get_clause}) for({for_clause})"
+    logger.debug("BQL option chain query: %s", query)
+
+    call_kwargs = {**safe_kwargs, **kwargs}
+    return _bql(query, backend=backend, **call_kwargs)
+
+
+def option_screen(
+    tickers: list[str],
+    flds: list[str] | None = None,
+    *,
+    backend: Backend | None = None,
+    ctx: BloombergContext | None = None,
+    **kwargs,
+):
+    """Return cross-option comparison analytics in one ``bdp`` call.
+
+    ``option_screen`` is intended for multi-contract comparison workflows where
+    users want one output table for several option tickers at once.
+
+    If *flds* is not provided, defaults to:
+
+    * Contract descriptors: ``NAME``, ``SECURITY_DES``
+    * Contract terms: ``OPT_STRIKE_PX``, ``OPT_EXPIRE_DT``, ``OPT_PUT_CALL``,
+      ``OPT_EXER_TYP``, ``OPT_UNDL_TICKER``
+    * Underlying/price context: ``OPT_UNDL_PX``, ``PX_LAST``, ``PX_BID``,
+      ``PX_ASK``
+    * Core risk: ``IVOL_MID``, ``DELTA_MID``, ``GAMMA_MID``, ``VEGA_MID``,
+      ``THETA_MID``, ``RHO_MID``
+    * Liquidity/positioning: ``OPEN_INT``, ``PX_VOLUME``
+
+    Args:
+        tickers: List of Bloomberg option tickers.
+        flds: Optional list of fields to request.
+        backend: Output backend. If ``None``, uses ``Backend.NARWHALS``.
+        ctx: Bloomberg context. If ``None``, extracted from *kwargs*.
+        **kwargs: Additional Bloomberg overrides and legacy kwargs support.
+
+    Returns:
+        DataFrame with requested analytics across all provided options.
+    """
+    from xbbg.api.reference import bdp
+    from xbbg.core.domain.context import split_kwargs
+
+    if ctx is None:
+        split = split_kwargs(**kwargs)
+        ctx = split.infra
+
+    safe_kwargs = ctx.to_kwargs()
+    call_kwargs = {**safe_kwargs, **kwargs}
+    return bdp(
+        tickers=tickers,
+        flds=flds or _OPTION_SCREEN_DEFAULT_FIELDS,
+        backend=backend or Backend.NARWHALS,
+        format=Format.SEMI_LONG,
+        **call_kwargs,
+    )

--- a/xbbg/ext/yas.py
+++ b/xbbg/ext/yas.py
@@ -20,7 +20,7 @@ __all__ = ["yas", "YieldType"]
 class YieldType(IntEnum):
     """Bloomberg YAS yield calculation type (YAS_YLD_FLAG override).
 
-    Used to specify whether to calculate Yield to Maturity or Yield to Call.
+    Used to specify the yield calculation convention.
 
     Examples:
         >>> from xbbg.ext import YieldType
@@ -28,12 +28,15 @@ class YieldType(IntEnum):
         <YieldType.YTM: 1>
         >>> YieldType.YTC
         <YieldType.YTC: 2>
-        >>> int(YieldType.YTM)
-        1
+        >>> int(YieldType.YTW)
+        3
     """
 
     YTM = 1  # Yield to Maturity
     YTC = 2  # Yield to Call
+    YTW = 3  # Yield to Worst
+    YTP = 4  # Yield to Put
+    CFY = 5  # Cash Flow Yield
 
 
 def yas(
@@ -46,6 +49,7 @@ def yas(
     yield_: float | None = None,
     price: float | None = None,
     benchmark: str | None = None,
+    workout_dt: str | datetime | None = None,
     backend: Backend | None = None,
     format: Format | None = None,
     **kwargs,
@@ -72,6 +76,8 @@ def yas(
             Maps to YAS_BOND_PX override.
         benchmark: Benchmark bond ticker for spread calculations.
             Maps to YAS_BNCHMRK_BOND override.
+        workout_dt: Workout date for yield-to-worst/call calculations (YYYYMMDD or datetime).
+            Maps to YAS_WORKOUT_DT override.
         backend: Output backend (e.g., Backend.PANDAS, Backend.POLARS).
             Defaults to global setting.
         format: Output format (e.g., Format.WIDE, Format.LONG).
@@ -88,25 +94,28 @@ def yas(
         >>> from xbbg.ext import YieldType  # doctest: +SKIP
         >>>
         >>> # Get yield to maturity for a bond
-        >>> blp.yas('US912810TD00 Govt')  # doctest: +SKIP
+        >>> blp.yas("US912810TD00 Govt")  # doctest: +SKIP
         >>>
         >>> # Get yield with custom settlement date
-        >>> blp.yas('US912810TD00 Govt', settle_dt='20240115')  # doctest: +SKIP
+        >>> blp.yas("US912810TD00 Govt", settle_dt="20240115")  # doctest: +SKIP
         >>>
         >>> # Get yield to call instead of yield to maturity
-        >>> blp.yas('XYZ Corp', yield_type=YieldType.YTC)  # doctest: +SKIP
+        >>> blp.yas("XYZ Corp", yield_type=YieldType.YTC)  # doctest: +SKIP
+        >>>
+        >>> # Get yield to worst
+        >>> blp.yas("XYZ Corp", yield_type=YieldType.YTW)  # doctest: +SKIP
         >>>
         >>> # Calculate yield from a given price
-        >>> blp.yas('US912810TD00 Govt', price=98.5)  # doctest: +SKIP
+        >>> blp.yas("US912810TD00 Govt", price=98.5)  # doctest: +SKIP
         >>>
         >>> # Calculate price from a given yield
-        >>> blp.yas('US912810TD00 Govt', flds='YAS_BOND_PX', yield_=4.5)  # doctest: +SKIP
+        >>> blp.yas("US912810TD00 Govt", flds="YAS_BOND_PX", yield_=4.5)  # doctest: +SKIP
         >>>
         >>> # Get spread to a specific benchmark
-        >>> blp.yas('XYZ Corp', flds='YAS_YLD_SPREAD', benchmark='US912810TD00 Govt')  # doctest: +SKIP
+        >>> blp.yas("XYZ Corp", flds="YAS_YLD_SPREAD", benchmark="US912810TD00 Govt")  # doctest: +SKIP
         >>>
         >>> # Get multiple YAS analytics
-        >>> blp.yas('US912810TD00 Govt', ['YAS_BOND_YLD', 'YAS_MOD_DUR', 'YAS_Z_SPREAD'])  # doctest: +SKIP
+        >>> blp.yas("US912810TD00 Govt", ["YAS_BOND_YLD", "YAS_MOD_DUR", "YAS_Z_SPREAD"])  # doctest: +SKIP
     """
     from xbbg.api.reference import bdp
 
@@ -149,6 +158,22 @@ def yas(
 
     if benchmark is not None:
         overrides["YAS_BNCHMRK_BOND"] = benchmark
+
+    if workout_dt is not None:
+        # Reuse the same date formatting logic as settle_dt
+        formatted_wo: str | None = None
+        if isinstance(workout_dt, str):
+            try:
+                dt = datetime.fromisoformat(workout_dt.replace("/", "-"))
+                formatted_wo = f"{dt.year:04d}{dt.month:02d}{dt.day:02d}"
+            except (ValueError, TypeError):
+                formatted_wo = workout_dt
+        elif isinstance(workout_dt, datetime):
+            formatted_wo = f"{workout_dt.year:04d}{workout_dt.month:02d}{workout_dt.day:02d}"
+        else:
+            formatted_wo = str(workout_dt)
+        if formatted_wo is not None:
+            overrides["YAS_WORKOUT_DT"] = formatted_wo
 
     # Merge with any additional kwargs overrides (kwargs take precedence)
     overrides.update(kwargs)

--- a/xbbg/tests/test_live_endpoints.py
+++ b/xbbg/tests/test_live_endpoints.py
@@ -1919,6 +1919,212 @@ def test_yas_enhanced():
     print("✓ enhanced yas() working correctly")
 
 
+@pytest.mark.live_endpoint
+def test_option_info():
+    """Test option_info returns metadata (strike, expiry, put/call, underlying)."""
+    print(f"\n{'=' * 80}")
+    print("Testing option_info (Strike / Expiry / Put-Call / Underlying)")
+    print(f"{'=' * 80}")
+
+    from xbbg.ext.options import option_info
+
+    ticker = "SPY US 03/20/26 C600 Equity"
+    result = option_info(ticker)
+    printable = result
+    to_native = getattr(result, "to_native", None)
+    if callable(to_native):
+        printable = to_native()
+    to_pandas = getattr(printable, "to_pandas", None)
+    if callable(to_pandas):
+        printable = to_pandas()
+
+    print(f"\noption_info({ticker!r}):")
+    print(printable)
+
+    assert not is_empty(result), "option_info should return data"
+    print("✓ option_info working correctly")
+
+
+@pytest.mark.live_endpoint
+def test_option_greeks():
+    """Test option_greeks returns Greeks and implied vol."""
+    print(f"\n{'=' * 80}")
+    print("Testing option_greeks (Greeks / Implied Vol)")
+    print(f"{'=' * 80}")
+
+    from xbbg.ext.options import option_greeks
+
+    ticker = "SPY US 03/20/26 C600 Equity"
+    result = option_greeks(ticker)
+    printable = result
+    to_native = getattr(result, "to_native", None)
+    if callable(to_native):
+        printable = to_native()
+    to_pandas = getattr(printable, "to_pandas", None)
+    if callable(to_pandas):
+        printable = to_pandas()
+
+    print(f"\noption_greeks({ticker!r}):")
+    print(printable)
+
+    assert not is_empty(result), "option_greeks should return data"
+    print("✓ option_greeks working correctly")
+
+
+@pytest.mark.live_endpoint
+def test_option_pricing():
+    """Test option_pricing returns pricing, intrinsic/time value, volume/OI."""
+    print(f"\n{'=' * 80}")
+    print("Testing option_pricing (Pricing / Intrinsic / Time Value / Volume / OI)")
+    print(f"{'=' * 80}")
+
+    from xbbg.ext.options import option_pricing
+
+    ticker = "SPY US 03/20/26 C600 Equity"
+    result = option_pricing(ticker)
+    printable = result
+    to_native = getattr(result, "to_native", None)
+    if callable(to_native):
+        printable = to_native()
+    to_pandas = getattr(printable, "to_pandas", None)
+    if callable(to_pandas):
+        printable = to_pandas()
+
+    print(f"\noption_pricing({ticker!r}):")
+    print(printable)
+
+    assert not is_empty(result), "option_pricing should return data"
+    print("✓ option_pricing working correctly")
+
+
+@pytest.mark.live_endpoint
+def test_option_chain():
+    """Test option_chain returns filtered chain."""
+    print(f"\n{'=' * 80}")
+    print("Testing option_chain (Filtered Chain)")
+    print(f"{'=' * 80}")
+
+    from xbbg.ext.options import option_chain, PutCall, StrikeRef
+
+    underlying = "SPY US Equity"
+    result = option_chain(underlying, put_call=PutCall.CALL, expiry_dt="20260320", strike=StrikeRef.ATM, points=5)
+    printable = result
+    to_native = getattr(result, "to_native", None)
+    if callable(to_native):
+        printable = to_native()
+    to_pandas = getattr(printable, "to_pandas", None)
+    if callable(to_pandas):
+        printable = to_pandas()
+
+    print(
+        f"\noption_chain({underlying!r}, put_call=PutCall.CALL, expiry_dt='20260320', strike=StrikeRef.ATM, points=5):"
+    )
+    print(printable)
+
+    assert not is_empty(result), "option_chain should return data"
+    print("✓ option_chain working correctly")
+
+
+@pytest.mark.live_endpoint
+def test_option_chain_bql():
+    """Test option_chain_bql returns filtered chain via BQL."""
+    print(f"\n{'=' * 80}")
+    print("Testing option_chain_bql (BQL Filtered Chain)")
+    print(f"{'=' * 80}")
+
+    from xbbg.ext.options import option_chain_bql, PutCall
+
+    underlying = "SPY US Equity"
+    result = option_chain_bql(
+        underlying,
+        put_call=PutCall.CALL,
+        expiry_start="2026-03-20",
+        expiry_end="2026-03-20",
+        strike_low=675,
+        strike_high=690,
+        delta_low=0.3,
+        delta_high=0.7,
+    )
+    printable = result
+    to_native = getattr(result, "to_native", None)
+    if callable(to_native):
+        printable = to_native()
+    to_pandas = getattr(printable, "to_pandas", None)
+    if callable(to_pandas):
+        printable = to_pandas()
+
+    print(
+        f"\noption_chain_bql({underlying!r}, put_call=PutCall.CALL, expiry_start='2026-03-20', expiry_end='2026-03-20', strike_low=675, strike_high=690, delta_low=0.3, delta_high=0.7):"
+    )
+    print(printable)
+
+    assert not is_empty(result), "option_chain_bql should return data"
+    print("✓ option_chain_bql working correctly")
+
+
+@pytest.mark.live_endpoint
+def test_option_screen():
+    """Test option_screen returns multi-option comparison."""
+    print(f"\n{'=' * 80}")
+    print("Testing option_screen (Multi-Option Comparison)")
+    print(f"{'=' * 80}")
+
+    from xbbg.ext.options import option_screen
+
+    tickers = ["SPY US 03/20/26 C680 Equity", "SPY US 03/20/26 P680 Equity"]
+    result = option_screen(tickers)
+    printable = result
+    to_native = getattr(result, "to_native", None)
+    if callable(to_native):
+        printable = to_native()
+    to_pandas = getattr(printable, "to_pandas", None)
+    if callable(to_pandas):
+        printable = to_pandas()
+
+    print(f"\noption_screen({tickers!r}):")
+    print(printable)
+
+    assert not is_empty(result), "option_screen should return data"
+    print("✓ option_screen working correctly")
+
+
+@pytest.mark.live_endpoint
+def test_option_chain_bql_advanced():
+    """Test option_chain_bql with advanced filters (moneyness, open interest, bid)."""
+    print(f"\n{'=' * 80}")
+    print("Testing option_chain_bql Advanced (Moneyness / Open Interest / Bid)")
+    print(f"{'=' * 80}")
+
+    from xbbg.ext.options import option_chain_bql, PutCall
+
+    underlying = "SPY US Equity"
+    result = option_chain_bql(
+        underlying,
+        put_call=PutCall.CALL,
+        expiry_start="2026-03-01",
+        expiry_end="2026-06-30",
+        moneyness_low=98,
+        moneyness_high=102,
+        min_open_int=500,
+        min_bid=1.0,
+    )
+    printable = result
+    to_native = getattr(result, "to_native", None)
+    if callable(to_native):
+        printable = to_native()
+    to_pandas = getattr(printable, "to_pandas", None)
+    if callable(to_pandas):
+        printable = to_pandas()
+
+    print(
+        f"\noption_chain_bql({underlying!r}, put_call=PutCall.CALL, expiry_start='2026-03-01', expiry_end='2026-06-30', moneyness_low=98, moneyness_high=102, min_open_int=500, min_bid=1.0):"
+    )
+    print(printable)
+
+    assert not is_empty(result), "option_chain_bql advanced should return data"
+    print("✓ option_chain_bql advanced working correctly")
+
+
 if __name__ == "__main__":
     # Allow running tests directly with verbose output
     print("\n" + "=" * 80)

--- a/xbbg/tests/test_live_endpoints.py
+++ b/xbbg/tests/test_live_endpoints.py
@@ -39,8 +39,21 @@ import threading
 
 import pandas as pd
 import pytest
+import narwhals as nw
 
 from xbbg import blp  # noqa: E402
+from xbbg.ext.cdx import (
+    cdx_basis,
+    cdx_cashflows,
+    cdx_curve,
+    cdx_default_prob,
+    cdx_defaults,
+    cdx_info,
+    cdx_pricing,
+    cdx_risk,
+    cdx_ticker as ext_cdx_ticker,
+)
+from xbbg.io.convert import is_empty
 
 
 # Version checking for regression testing
@@ -94,6 +107,10 @@ TEST_TICKERS = ["AAPL US Equity", "MSFT US Equity"]
 TEST_INDEX = "SPX Index"
 TEST_FIELDS = ["Security_Name", "PX_LAST"]
 TEST_SINGLE_FIELD = "PX_LAST"
+
+# CDX test parameters
+CDX_GEN_IG = "CDX IG CDSI GEN 5Y Corp"
+CDX_GEN_HY = "CDX HY CDSI GEN 5Y Corp"
 
 
 # Date ranges - use recent dates but keep small
@@ -1389,6 +1406,154 @@ def test_active_cdx():
         print(f"\nGeneric CDX ticker: {generic_cdx}")
         print(f"Active contract: {result}")
         print("✓ active_cdx() endpoint working correctly")
+
+
+@pytest.mark.live_endpoint
+def test_cdx_ticker_version_format():
+    """Test CDX ticker resolution produces correct version token format.
+
+    IG (VERSION=1) should NOT have a V token.
+    HY (VERSION>1) should have a SEPARATE V token (e.g. 'S45 V2' not 'S45V2').
+    """
+    # Use ext_cdx_ticker to test directly without deprecation wrapper
+    ig = ext_cdx_ticker(CDX_GEN_IG, END_DATE.strftime("%Y-%m-%d"))
+    assert ig, "IG ticker resolution should not be empty"
+    tokens = ig.split()
+    # Find the series token
+    series_tok = next((t for t in tokens if t.startswith("S") and t[1:].isdigit()), None)
+    assert series_tok is not None, f"Should have a series token like S45, got: {ig}"
+    series_idx = tokens.index(series_tok)
+    # IG should NOT have a version token right after series
+    if series_idx + 1 < len(tokens):
+        next_tok = tokens[series_idx + 1]
+        assert not (next_tok.startswith("V") and next_tok[1:].isdigit()), (
+            f"IG should not have version token but got '{next_tok}' in: {ig}"
+        )
+
+    hy = ext_cdx_ticker(CDX_GEN_HY, END_DATE.strftime("%Y-%m-%d"))
+    assert hy, "HY ticker resolution should not be empty"
+    tokens = hy.split()
+    series_tok = next((t for t in tokens if t.startswith("S") and t[1:].isdigit()), None)
+    assert series_tok is not None, f"Should have a series token like S45, got: {hy}"
+    series_idx = tokens.index(series_tok)
+    # HY should have a SEPARATE version token (V2, V3, etc.) right after series
+    assert series_idx + 1 < len(tokens), f"HY should have token after series, got: {hy}"
+    version_tok = tokens[series_idx + 1]
+    assert version_tok.startswith("V") and version_tok[1:].isdigit(), (
+        f"HY should have separate version token like V2 after series, got '{version_tok}' in: {hy}"
+    )
+
+    print(f"\nIG resolved: {ig}")
+    print(f"HY resolved: {hy}")
+    print("✓ CDX ticker version format correct")
+
+
+@pytest.mark.live_endpoint
+def test_cdx_info_endpoint():
+    """Test cdx_info() returns metadata for a CDX ticker."""
+    result = cdx_info(CDX_GEN_IG)
+    assert not is_empty(result), "cdx_info should return data"
+
+    nw_result = nw.from_native(result, eager_only=True)
+    assert "ticker" in nw_result.columns, "Should have ticker column"
+    assert "field" in nw_result.columns, "Should have field column"
+    assert "value" in nw_result.columns, "Should have value column"
+    assert nw_result.shape[0] >= 4, f"Should have at least 4 field rows, got {nw_result.shape[0]}"
+
+    print(f"\ncdx_info result ({nw_result.shape[0]} fields):")
+    print(result)
+    print("✓ cdx_info endpoint working correctly")
+
+
+@pytest.mark.live_endpoint
+def test_cdx_defaults_endpoint():
+    """Test cdx_defaults() returns default history for CDX HY (which has defaults)."""
+    # Resolve HY ticker first (it has defaults)
+    hy = ext_cdx_ticker(CDX_GEN_HY, END_DATE.strftime("%Y-%m-%d"))
+    assert hy, "HY ticker resolution should not be empty"
+
+    result = cdx_defaults(hy)
+    assert not is_empty(result), "cdx_defaults for HY should return data (HY has credit events)"
+
+    print(f"\ncdx_defaults result for {hy}:")
+    print(result)
+    print("✓ cdx_defaults endpoint working correctly")
+
+
+@pytest.mark.live_endpoint
+def test_cdx_pricing_endpoint():
+    """Test cdx_pricing() returns pricing analytics."""
+    result = cdx_pricing(CDX_GEN_IG)
+    assert not is_empty(result), "cdx_pricing should return data"
+
+    nw_result = nw.from_native(result, eager_only=True)
+    assert nw_result.shape[0] >= 3, f"Should have at least 3 pricing fields, got {nw_result.shape[0]}"
+
+    # Verify px_last is present
+    fields = nw_result.select("field").to_series().to_list()
+    assert "px_last" in fields, f"Should have px_last field, got: {fields}"
+
+    print(f"\ncdx_pricing result ({nw_result.shape[0]} fields):")
+    print(result)
+    print("✓ cdx_pricing endpoint working correctly")
+
+
+@pytest.mark.live_endpoint
+def test_cdx_risk_endpoint():
+    """Test cdx_risk() returns risk analytics (DV01, duration, etc.)."""
+    result = cdx_risk(CDX_GEN_IG)
+    assert not is_empty(result), "cdx_risk should return data"
+
+    nw_result = nw.from_native(result, eager_only=True)
+    assert nw_result.shape[0] >= 2, f"Should have at least 2 risk fields, got {nw_result.shape[0]}"
+
+    print(f"\ncdx_risk result ({nw_result.shape[0]} fields):")
+    print(result)
+    print("✓ cdx_risk endpoint working correctly")
+
+
+@pytest.mark.live_endpoint
+def test_cdx_basis_endpoint():
+    """Test cdx_basis() returns intrinsic value and basis analytics."""
+    result = cdx_basis(CDX_GEN_IG)
+    assert not is_empty(result), "cdx_basis should return data"
+
+    nw_result = nw.from_native(result, eager_only=True)
+    assert nw_result.shape[0] >= 2, f"Should have at least 2 basis fields, got {nw_result.shape[0]}"
+
+    print(f"\ncdx_basis result ({nw_result.shape[0]} fields):")
+    print(result)
+    print("✓ cdx_basis endpoint working correctly")
+
+
+@pytest.mark.live_endpoint
+def test_cdx_default_prob_endpoint():
+    """Test cdx_default_prob() returns default probability term structure."""
+    result = cdx_default_prob(CDX_GEN_IG)
+    assert not is_empty(result), "cdx_default_prob should return data"
+
+    nw_result = nw.from_native(result, eager_only=True)
+    assert nw_result.shape[0] >= 5, f"Should have at least 5 term structure rows, got {nw_result.shape[0]}"
+
+    print(f"\ncdx_default_prob result ({nw_result.shape[0]} rows):")
+    print(result)
+    print("✓ cdx_default_prob endpoint working correctly")
+
+
+@pytest.mark.live_endpoint
+def test_cdx_curve_endpoint():
+    """Test cdx_curve() returns multi-tenor term structure."""
+    result = cdx_curve(CDX_GEN_IG, tenors=["3Y", "5Y", "10Y"])
+    assert not is_empty(result), "cdx_curve should return data"
+
+    nw_result = nw.from_native(result, eager_only=True)
+    # Should have results for multiple tenors
+    tickers = nw_result.select("ticker").to_series().unique().to_list()
+    assert len(tickers) >= 2, f"Should have at least 2 tenor tickers, got: {tickers}"
+
+    print(f"\ncdx_curve result ({nw_result.shape[0]} rows, {len(tickers)} tenors):")
+    print(result)
+    print("✓ cdx_curve endpoint working correctly")
 
 
 @pytest.mark.live_endpoint

--- a/xbbg/tests/test_live_endpoints.py
+++ b/xbbg/tests/test_live_endpoints.py
@@ -37,14 +37,21 @@ from datetime import date, datetime, timedelta
 import sys
 import threading
 
+import narwhals as nw
 import pandas as pd
 import pytest
-import narwhals as nw
 
 from xbbg import blp  # noqa: E402
+from xbbg.ext.bonds import (
+    bond_cashflows,
+    bond_curve,
+    bond_info,
+    bond_key_rates,
+    bond_risk,
+    bond_spreads,
+)
 from xbbg.ext.cdx import (
     cdx_basis,
-    cdx_cashflows,
     cdx_curve,
     cdx_default_prob,
     cdx_defaults,
@@ -54,14 +61,6 @@ from xbbg.ext.cdx import (
     cdx_ticker as ext_cdx_ticker,
 )
 from xbbg.io.convert import is_empty
-from xbbg.ext.bonds import (
-    bond_cashflows,
-    bond_curve,
-    bond_info,
-    bond_key_rates,
-    bond_risk,
-    bond_spreads,
-)
 
 
 # Version checking for regression testing
@@ -1886,7 +1885,7 @@ def test_yas_enhanced():
     print("Testing yas() Enhanced (YTW + workout_dt)")
     print(f"{'=' * 80}")
 
-    from xbbg.ext import YieldType, yas
+    from xbbg.ext import yas
 
     ticker = "/isin/US91282CNC19"
 
@@ -2004,7 +2003,7 @@ def test_option_chain():
     print("Testing option_chain (Filtered Chain)")
     print(f"{'=' * 80}")
 
-    from xbbg.ext.options import option_chain, PutCall, StrikeRef
+    from xbbg.ext.options import PutCall, StrikeRef, option_chain
 
     underlying = "SPY US Equity"
     result = option_chain(underlying, put_call=PutCall.CALL, expiry_dt="20260320", strike=StrikeRef.ATM, points=5)
@@ -2032,7 +2031,7 @@ def test_option_chain_bql():
     print("Testing option_chain_bql (BQL Filtered Chain)")
     print(f"{'=' * 80}")
 
-    from xbbg.ext.options import option_chain_bql, PutCall
+    from xbbg.ext.options import PutCall, option_chain_bql
 
     underlying = "SPY US Equity"
     result = option_chain_bql(
@@ -2095,7 +2094,7 @@ def test_option_chain_bql_advanced():
     print("Testing option_chain_bql Advanced (Moneyness / Open Interest / Bid)")
     print(f"{'=' * 80}")
 
-    from xbbg.ext.options import option_chain_bql, PutCall
+    from xbbg.ext.options import PutCall, option_chain_bql
 
     underlying = "SPY US Equity"
     result = option_chain_bql(

--- a/xbbg/tests/test_live_endpoints.py
+++ b/xbbg/tests/test_live_endpoints.py
@@ -54,6 +54,14 @@ from xbbg.ext.cdx import (
     cdx_ticker as ext_cdx_ticker,
 )
 from xbbg.io.convert import is_empty
+from xbbg.ext.bonds import (
+    bond_cashflows,
+    bond_curve,
+    bond_info,
+    bond_key_rates,
+    bond_risk,
+    bond_spreads,
+)
 
 
 # Version checking for regression testing
@@ -1725,6 +1733,190 @@ def test_bdp_mixed_type_multiple_tickers():
     print(f"Columns: {list(result.columns)}")
     print(f"Dtypes:\n{result.dtypes}")
     print("✓ BDP mixed-type fields with multiple tickers working correctly")
+
+
+@pytest.mark.live_endpoint
+def test_bond_info():
+    """Test bond_info returns static reference metadata for a Treasury."""
+    print(f"\n{'=' * 80}")
+    print("Testing bond_info (Bond Reference Metadata)")
+    print(f"{'=' * 80}")
+
+    ticker = "/isin/US91282CNC19"
+    result = bond_info(ticker)
+    printable = result
+    to_native = getattr(result, "to_native", None)
+    if callable(to_native):
+        printable = to_native()
+    to_pandas = getattr(printable, "to_pandas", None)
+    if callable(to_pandas):
+        printable = to_pandas()
+
+    print(f"\nbond_info({ticker!r}):")
+    print(printable)
+
+    assert not is_empty(result), "bond_info should return data"
+    print("✓ bond_info working correctly")
+
+
+@pytest.mark.live_endpoint
+def test_bond_risk():
+    """Test bond_risk returns duration, convexity, DV01 analytics."""
+    print(f"\n{'=' * 80}")
+    print("Testing bond_risk (Duration / Convexity / DV01)")
+    print(f"{'=' * 80}")
+
+    ticker = "/isin/US91282CNC19"
+    result = bond_risk(ticker)
+    printable = result
+    to_native = getattr(result, "to_native", None)
+    if callable(to_native):
+        printable = to_native()
+    to_pandas = getattr(printable, "to_pandas", None)
+    if callable(to_pandas):
+        printable = to_pandas()
+
+    print(f"\nbond_risk({ticker!r}):")
+    print(printable)
+
+    assert not is_empty(result), "bond_risk should return data"
+    print("✓ bond_risk working correctly")
+
+
+@pytest.mark.live_endpoint
+def test_bond_spreads():
+    """Test bond_spreads returns OAS, Z-spread, I-spread, ASW analytics."""
+    print(f"\n{'=' * 80}")
+    print("Testing bond_spreads (OAS / Z-Spread / I-Spread / ASW)")
+    print(f"{'=' * 80}")
+
+    ticker = "/isin/US91282CNC19"
+    result = bond_spreads(ticker)
+    printable = result
+    to_native = getattr(result, "to_native", None)
+    if callable(to_native):
+        printable = to_native()
+    to_pandas = getattr(printable, "to_pandas", None)
+    if callable(to_pandas):
+        printable = to_pandas()
+
+    print(f"\nbond_spreads({ticker!r}):")
+    print(printable)
+
+    assert not is_empty(result), "bond_spreads should return data"
+    print("✓ bond_spreads working correctly")
+
+
+@pytest.mark.live_endpoint
+def test_bond_cashflows():
+    """Test bond_cashflows returns cash flow schedule via bds DES_CASH_FLOW."""
+    print(f"\n{'=' * 80}")
+    print("Testing bond_cashflows (DES_CASH_FLOW via bds)")
+    print(f"{'=' * 80}")
+
+    ticker = "/isin/US91282CNC19"
+    result = bond_cashflows(ticker)
+    printable = result
+    to_native = getattr(result, "to_native", None)
+    if callable(to_native):
+        printable = to_native()
+    to_pandas = getattr(printable, "to_pandas", None)
+    if callable(to_pandas):
+        printable = to_pandas()
+
+    print(f"\nbond_cashflows({ticker!r}):")
+    print(printable)
+
+    assert not is_empty(result), "bond_cashflows should return data"
+    print("✓ bond_cashflows working correctly")
+
+
+@pytest.mark.live_endpoint
+def test_bond_key_rates():
+    """Test bond_key_rates returns key rate durations and risks."""
+    print(f"\n{'=' * 80}")
+    print("Testing bond_key_rates (Key Rate Durations / Risks)")
+    print(f"{'=' * 80}")
+
+    ticker = "/isin/US91282CNC19"
+    result = bond_key_rates(ticker)
+    printable = result
+    to_native = getattr(result, "to_native", None)
+    if callable(to_native):
+        printable = to_native()
+    to_pandas = getattr(printable, "to_pandas", None)
+    if callable(to_pandas):
+        printable = to_pandas()
+
+    print(f"\nbond_key_rates({ticker!r}):")
+    print(printable)
+
+    assert not is_empty(result), "bond_key_rates should return data"
+    print("✓ bond_key_rates working correctly")
+
+
+@pytest.mark.live_endpoint
+def test_bond_curve():
+    """Test bond_curve returns multi-bond relative value analytics."""
+    print(f"\n{'=' * 80}")
+    print("Testing bond_curve (Multi-Bond Relative Value)")
+    print(f"{'=' * 80}")
+
+    tickers = ["/isin/US91282CNC19", "T 4 02/28/31 Govt"]
+    result = bond_curve(tickers)
+    printable = result
+    to_native = getattr(result, "to_native", None)
+    if callable(to_native):
+        printable = to_native()
+    to_pandas = getattr(printable, "to_pandas", None)
+    if callable(to_pandas):
+        printable = to_pandas()
+
+    print(f"\nbond_curve({tickers!r}):")
+    print(printable)
+
+    assert not is_empty(result), "bond_curve should return data"
+    print("✓ bond_curve working correctly")
+
+
+@pytest.mark.live_endpoint
+def test_yas_enhanced():
+    """Test enhanced yas() with new YieldType.YTW and workout_dt override."""
+    print(f"\n{'=' * 80}")
+    print("Testing yas() Enhanced (YTW + workout_dt)")
+    print(f"{'=' * 80}")
+
+    from xbbg.ext import YieldType, yas
+
+    ticker = "/isin/US91282CNC19"
+
+    # Basic yield
+    result1 = yas(ticker)
+    printable1 = result1
+    to_native = getattr(result1, "to_native", None)
+    if callable(to_native):
+        printable1 = to_native()
+    to_pandas = getattr(printable1, "to_pandas", None)
+    if callable(to_pandas):
+        printable1 = to_pandas()
+    print(f"\nyas({ticker!r}):")
+    print(printable1)
+
+    # Multi-field
+    result2 = yas(ticker, ["YAS_BOND_YLD", "YAS_MOD_DUR", "YAS_ZSPREAD"])
+    printable2 = result2
+    to_native = getattr(result2, "to_native", None)
+    if callable(to_native):
+        printable2 = to_native()
+    to_pandas = getattr(printable2, "to_pandas", None)
+    if callable(to_pandas):
+        printable2 = to_pandas()
+    print(f"\nyas({ticker!r}, ['YAS_BOND_YLD', 'YAS_MOD_DUR', 'YAS_ZSPREAD']):")
+    print(printable2)
+
+    assert not is_empty(result1), "yas basic should return data"
+    assert not is_empty(result2), "yas multi-field should return data"
+    print("✓ enhanced yas() working correctly")
 
 
 if __name__ == "__main__":

--- a/xbbg/tests/test_live_endpoints.py
+++ b/xbbg/tests/test_live_endpoints.py
@@ -1450,7 +1450,7 @@ def test_cdx_ticker_version_format():
 
     print(f"\nIG resolved: {ig}")
     print(f"HY resolved: {hy}")
-    print("✓ CDX ticker version format correct")
+    print("[PASS] CDX ticker version format correct")
 
 
 @pytest.mark.live_endpoint
@@ -1467,7 +1467,7 @@ def test_cdx_info_endpoint():
 
     print(f"\ncdx_info result ({nw_result.shape[0]} fields):")
     print(result)
-    print("✓ cdx_info endpoint working correctly")
+    print("[PASS] cdx_info endpoint working correctly")
 
 
 @pytest.mark.live_endpoint
@@ -1482,7 +1482,7 @@ def test_cdx_defaults_endpoint():
 
     print(f"\ncdx_defaults result for {hy}:")
     print(result)
-    print("✓ cdx_defaults endpoint working correctly")
+    print("[PASS] cdx_defaults endpoint working correctly")
 
 
 @pytest.mark.live_endpoint
@@ -1500,7 +1500,7 @@ def test_cdx_pricing_endpoint():
 
     print(f"\ncdx_pricing result ({nw_result.shape[0]} fields):")
     print(result)
-    print("✓ cdx_pricing endpoint working correctly")
+    print("[PASS] cdx_pricing endpoint working correctly")
 
 
 @pytest.mark.live_endpoint
@@ -1514,7 +1514,7 @@ def test_cdx_risk_endpoint():
 
     print(f"\ncdx_risk result ({nw_result.shape[0]} fields):")
     print(result)
-    print("✓ cdx_risk endpoint working correctly")
+    print("[PASS] cdx_risk endpoint working correctly")
 
 
 @pytest.mark.live_endpoint
@@ -1528,7 +1528,7 @@ def test_cdx_basis_endpoint():
 
     print(f"\ncdx_basis result ({nw_result.shape[0]} fields):")
     print(result)
-    print("✓ cdx_basis endpoint working correctly")
+    print("[PASS] cdx_basis endpoint working correctly")
 
 
 @pytest.mark.live_endpoint
@@ -1542,7 +1542,7 @@ def test_cdx_default_prob_endpoint():
 
     print(f"\ncdx_default_prob result ({nw_result.shape[0]} rows):")
     print(result)
-    print("✓ cdx_default_prob endpoint working correctly")
+    print("[PASS] cdx_default_prob endpoint working correctly")
 
 
 @pytest.mark.live_endpoint
@@ -1558,7 +1558,7 @@ def test_cdx_curve_endpoint():
 
     print(f"\ncdx_curve result ({nw_result.shape[0]} rows, {len(tickers)} tenors):")
     print(result)
-    print("✓ cdx_curve endpoint working correctly")
+    print("[PASS] cdx_curve endpoint working correctly")
 
 
 @pytest.mark.skip(
@@ -1755,7 +1755,7 @@ def test_bond_info():
     print(printable)
 
     assert not is_empty(result), "bond_info should return data"
-    print("✓ bond_info working correctly")
+    print("[PASS] bond_info working correctly")
 
 
 @pytest.mark.live_endpoint
@@ -1779,7 +1779,7 @@ def test_bond_risk():
     print(printable)
 
     assert not is_empty(result), "bond_risk should return data"
-    print("✓ bond_risk working correctly")
+    print("[PASS] bond_risk working correctly")
 
 
 @pytest.mark.live_endpoint
@@ -1803,7 +1803,7 @@ def test_bond_spreads():
     print(printable)
 
     assert not is_empty(result), "bond_spreads should return data"
-    print("✓ bond_spreads working correctly")
+    print("[PASS] bond_spreads working correctly")
 
 
 @pytest.mark.live_endpoint
@@ -1827,7 +1827,7 @@ def test_bond_cashflows():
     print(printable)
 
     assert not is_empty(result), "bond_cashflows should return data"
-    print("✓ bond_cashflows working correctly")
+    print("[PASS] bond_cashflows working correctly")
 
 
 @pytest.mark.live_endpoint
@@ -1851,7 +1851,7 @@ def test_bond_key_rates():
     print(printable)
 
     assert not is_empty(result), "bond_key_rates should return data"
-    print("✓ bond_key_rates working correctly")
+    print("[PASS] bond_key_rates working correctly")
 
 
 @pytest.mark.live_endpoint
@@ -1875,7 +1875,7 @@ def test_bond_curve():
     print(printable)
 
     assert not is_empty(result), "bond_curve should return data"
-    print("✓ bond_curve working correctly")
+    print("[PASS] bond_curve working correctly")
 
 
 @pytest.mark.live_endpoint
@@ -1915,7 +1915,7 @@ def test_yas_enhanced():
 
     assert not is_empty(result1), "yas basic should return data"
     assert not is_empty(result2), "yas multi-field should return data"
-    print("✓ enhanced yas() working correctly")
+    print("[PASS] enhanced yas() working correctly")
 
 
 @pytest.mark.live_endpoint
@@ -1941,7 +1941,7 @@ def test_option_info():
     print(printable)
 
     assert not is_empty(result), "option_info should return data"
-    print("✓ option_info working correctly")
+    print("[PASS] option_info working correctly")
 
 
 @pytest.mark.live_endpoint
@@ -1967,7 +1967,7 @@ def test_option_greeks():
     print(printable)
 
     assert not is_empty(result), "option_greeks should return data"
-    print("✓ option_greeks working correctly")
+    print("[PASS] option_greeks working correctly")
 
 
 @pytest.mark.live_endpoint
@@ -1993,7 +1993,7 @@ def test_option_pricing():
     print(printable)
 
     assert not is_empty(result), "option_pricing should return data"
-    print("✓ option_pricing working correctly")
+    print("[PASS] option_pricing working correctly")
 
 
 @pytest.mark.live_endpoint
@@ -2021,7 +2021,7 @@ def test_option_chain():
     print(printable)
 
     assert not is_empty(result), "option_chain should return data"
-    print("✓ option_chain working correctly")
+    print("[PASS] option_chain working correctly")
 
 
 @pytest.mark.live_endpoint
@@ -2058,7 +2058,7 @@ def test_option_chain_bql():
     print(printable)
 
     assert not is_empty(result), "option_chain_bql should return data"
-    print("✓ option_chain_bql working correctly")
+    print("[PASS] option_chain_bql working correctly")
 
 
 @pytest.mark.live_endpoint
@@ -2084,7 +2084,7 @@ def test_option_screen():
     print(printable)
 
     assert not is_empty(result), "option_screen should return data"
-    print("✓ option_screen working correctly")
+    print("[PASS] option_screen working correctly")
 
 
 @pytest.mark.live_endpoint
@@ -2121,7 +2121,7 @@ def test_option_chain_bql_advanced():
     print(printable)
 
     assert not is_empty(result), "option_chain_bql advanced should return data"
-    print("✓ option_chain_bql advanced working correctly")
+    print("[PASS] option_chain_bql advanced working correctly")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Comprehensive analytics modules for three instrument types, all verified against authorized-environment:

### Phase 1 — CDX Credit Index (`ext/cdx.py`)
- Bug fixes: SEMI_LONG column-name check, CDX HY ticker format (`S44 V1` not `S44V1`)
- 8 analytics functions: `cdx_info()`, `cdx_defaults()`, `cdx_pricing()`, `cdx_risk()`, `cdx_basis()`, `cdx_default_prob()`, `cdx_cashflows()`, `cdx_curve()`

### Phase 2 — Fixed Income Bonds (`ext/bonds.py`)
- New module (515 lines): `bond_info()`, `bond_risk()`, `bond_spreads()`, `bond_cashflows()`, `bond_key_rates()`, `bond_curve()`
- Enhanced `ext/yas.py`: added `YieldType.YTW`/`YTP`/`CFY`, `workout_dt` override
- 28+ bdp fields + 2 bds bulk fields confirmed on 10yr Treasury

### Phase 3 — Options Analytics (`ext/options.py`)
- New module (838 lines) with 5 enums (`PutCall`, `ChainPeriodicity`, `StrikeRef`, `ExerciseType`, `ExpiryMatch`)
- 6 functions: `option_info()`, `option_greeks()`, `option_pricing()`, `option_chain()`, `option_chain_bql()`, `option_screen()`
- `option_chain()` uses `CHAIN_TICKERS` with Bloomberg overrides for basic filtering
- `option_chain_bql()` uses BQL for rich filtering by greeks, implied vol, moneyness, open interest, bid/ask, exchange code
- Fix: `BlockDataTransformer` duplicate column dedup after standardization (CHAIN_TICKERS returns `Ticker` which collides with metadata `ticker`)

### Testing
- 22 live endpoint tests (8 CDX + 7 FI + 7 options), all passing
- 3 verification scripts (`scripts/cdx_request.py`, `fi_request.py`, `options_request.py`)

### Files Changed
- 12 files, +3472 / -103 lines