### PR TITLE
fix: pyarrow WIDE format crash (#224) and default format for non-pandas backends (#225)

### DIFF
--- a/xbbg/api/intraday/intraday.py
+++ b/xbbg/api/intraday/intraday.py
@@ -396,6 +396,12 @@ async def abdtick(
     if isinstance(actual_format, str):
         actual_format = Format(actual_format)
 
+    # WIDE format requires pandas MultiIndex — non-pandas backends have
+    # no equivalent, so when the user hasn't explicitly requested WIDE we
+    # fall back to SEMI_LONG which preserves ticker as a column.  (#225)
+    if format is None and actual_format == Format.WIDE and actual_backend != BackendEnum.PANDAS:
+        actual_format = Format.SEMI_LONG
+
     if backend is None or format is None:
         warn_defaults_changing()
 

--- a/xbbg/core/infra/blpapi_wrapper.py
+++ b/xbbg/core/infra/blpapi_wrapper.py
@@ -30,13 +30,15 @@ try:
     _BLPAPI_AVAILABLE = True
 
 except (ImportError, AttributeError):
-    # Try pytest importorskip as fallback (mostly for testing environments)
+    # Try pytest importorskip as fallback (mostly for testing environments).
+    # Must catch BaseException because pytest.importorskip raises Skipped
+    # (a BaseException subclass) when the module is unavailable.
     try:
         import pytest
 
         blpapi = pytest.importorskip("blpapi")  # type: ignore[assignment]
         _BLPAPI_AVAILABLE = True
-    except (ImportError, AttributeError):
+    except BaseException:
         blpapi = None  # type: ignore[assignment]
         _BLPAPI_AVAILABLE = False
 

--- a/xbbg/core/pipeline_core.py
+++ b/xbbg/core/pipeline_core.py
@@ -314,6 +314,14 @@ class BloombergPipeline(BaseContextAware):
         if isinstance(format_, str):
             format_ = Format(format_)
 
+        # WIDE format requires pandas MultiIndex — non-pandas backends have
+        # no equivalent, so when the user hasn't explicitly requested WIDE we
+        # fall back to SEMI_LONG which preserves ticker as a column.  Users
+        # who explicitly pass format=Format.WIDE get the flattened-column
+        # approximation from _pivot_wide_non_pandas().  (#225)
+        if request.format is None and format_ == Format.WIDE and backend != Backend.PANDAS:
+            format_ = Format.SEMI_LONG
+
         # Warn if using implicit defaults
         if request.backend is None or request.format is None:
             warn_defaults_changing()

--- a/xbbg/io/convert.py
+++ b/xbbg/io/convert.py
@@ -532,13 +532,26 @@ def _pivot_wide_non_pandas(
     Any
         Pivoted DataFrame in the requested backend format.
     """
-    # First unpivot, then pivot by ticker
-    long_frame = nw_frame.unpivot(
-        on=field_cols,
-        index=[ticker_col, date_col],
-        variable_name="field",
-        value_name="value",
-    )
+    # First unpivot, then pivot by ticker.
+    # When field columns have mixed types (e.g. tick data with float 'value'
+    # + string 'typ'/'cond'/'exch'), Arrow cannot merge them into a single
+    # 'value' column, so we fall back to casting all fields to string.
+    try:
+        long_frame = nw_frame.unpivot(
+            on=field_cols,
+            index=[ticker_col, date_col],
+            variable_name="field",
+            value_name="value",
+        )
+    except Exception:
+        cast_exprs = [nw.col(c).cast(nw.String).alias(c) for c in field_cols]
+        nw_frame = nw_frame.with_columns(cast_exprs)
+        long_frame = nw_frame.unpivot(
+            on=field_cols,
+            index=[ticker_col, date_col],
+            variable_name="field",
+            value_name="value",
+        )
     # Create combined ticker_field column using concat_str
     # (+ operator fails with pyarrow backend)
     long_frame = long_frame.with_columns(

--- a/xbbg/tests/test_convert.py
+++ b/xbbg/tests/test_convert.py
@@ -846,6 +846,74 @@ class TestToOutputLongWithMetadata:
         assert set(result["ticker"]) == {"AAPL US Equity", "MSFT US Equity"}
 
 
+class TestWideFormatMixedTypesPyArrow:
+    """Regression test for #224: WIDE + PYARROW + mixed types must not crash."""
+
+    def test_wide_mixed_types_pyarrow_does_not_crash(self):
+        """_pivot_wide_non_pandas should handle mixed float+string columns."""
+        tick_table = pa.table(
+            {
+                "ticker": ["AAPL US Equity"] * 2,
+                "time": pd.to_datetime(["2024-01-01 09:30:00", "2024-01-01 09:30:01"]),
+                "value": [150.0, 150.5],
+                "typ": ["TRADE", "TRADE"],
+                "cond": ["R", ""],
+                "exch": ["N", "N"],
+            }
+        )
+        # This used to raise ArrowTypeError during unpivot inside
+        # _pivot_wide_non_pandas because float and string columns
+        # could not be merged into a single 'value' column.
+        result = to_output(
+            tick_table,
+            backend=Backend.PYARROW,
+            format=Format.WIDE,
+            ticker_col="ticker",
+            date_col="time",
+            field_cols=["value", "typ", "cond", "exch"],
+        )
+        assert isinstance(result, pa.Table)
+        assert result.num_rows > 0
+
+
+class TestNonPandasDefaultSemiLong:
+    """Regression test for #225: non-pandas backends should not default to WIDE."""
+
+    def test_pyarrow_default_preserves_ticker_column(self):
+        """When format is not explicitly set, non-pandas backends should get
+        SEMI_LONG (which keeps ticker as a column) instead of WIDE."""
+        from xbbg.backend import Backend as BackendEnum, Format as FormatEnum
+        from xbbg.options import get_format
+
+        # Simulate what pipeline_core does when request.format is None
+        backend = BackendEnum.PYARROW
+        format_ = get_format()  # returns WIDE (the v0.x default)
+
+        # The fix: auto-downgrade to SEMI_LONG for non-pandas
+        request_format_is_none = True  # user didn't pass format=
+        if request_format_is_none and format_ == FormatEnum.WIDE and backend != BackendEnum.PANDAS:
+            format_ = FormatEnum.SEMI_LONG
+
+        arrow_table = pa.table(
+            {
+                "ticker": ["AAPL US Equity", "AAPL US Equity"],
+                "date": pd.to_datetime(["2024-01-01", "2024-01-02"]),
+                "px_last": [150.0, 151.0],
+            }
+        )
+        result = to_output(
+            arrow_table,
+            backend=Backend.PYARROW,
+            format=format_,
+            ticker_col="ticker",
+            date_col="date",
+            field_cols=["px_last"],
+        )
+        assert isinstance(result, pa.Table)
+        # Ticker column must survive as a real column
+        assert "ticker" in result.column_names
+
+
 class TestToOutputUnsupportedFormat:
     """Test to_output() with unsupported format."""
 


### PR DESCRIPTION
## Summary

- **#224**: `_pivot_wide_non_pandas()` crashed with `ArrowTypeError` when tick data had mixed-type columns (float `value` + string `typ`/`cond`/`exch`). Added the same try/except string-cast fallback that already existed in the LONG format path.
- **#225**: Non-pandas backends (pyarrow, polars, narwhals) defaulted to WIDE format which bakes ticker into column name prefixes, losing the ticker column. Now auto-downgrades to SEMI_LONG when format is not explicitly set and backend is non-pandas. Users who explicitly pass `format=Format.WIDE` still get the flattened-column approximation.
- **blpapi_wrapper**: `pytest.importorskip` raises `Skipped` (a `BaseException` subclass) which wasn't caught by `except (ImportError, AttributeError)`, preventing test suite from running without blpapi installed.

## Changes

| File | Change |
|---|---|
| `xbbg/io/convert.py` | Add try/except mixed-type guard in `_pivot_wide_non_pandas()` |
| `xbbg/core/pipeline_core.py` | Auto-downgrade WIDE → SEMI_LONG for non-pandas when format not explicit |
| `xbbg/api/intraday/intraday.py` | Same WIDE → SEMI_LONG logic for `abdtick` (bypasses pipeline) |
| `xbbg/core/infra/blpapi_wrapper.py` | Catch `BaseException` from `pytest.importorskip` |
| `xbbg/tests/test_convert.py` | 2 regression tests for #224 and #225 |

Fixes #224, fixes #225