### PR TITLE
docs(changelog): note exchange/session rust rollout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 - **Streaming performance enhancements**: Per-subscription config (`flush_threshold`, `overflow_policy`, `stream_capacity`), observability metrics via shared atomics, `tick_mode` support
 - **Live integration tests**: 69 tests across `test_ext_bonds.py` (21), `test_ext_options.py` (20), `test_ext_cdx.py` (22) covering all ext module functions
 - **Streaming tests**: Tests for `tick_mode`, per-subscription config, and observability metrics
+- **Rust exchange/session APIs**: Added low-level exchange resolution support with `ExchangeInfo` metadata, runtime exchange overrides, session timezone conversion utilities, and `market_timing` helpers in the Rust layer (`xbbg-ext`, `xbbg-async`, `pyo3-xbbg`)
+- **Live exchange smoke test**: Added `py-xbbg/tests/live/test_exchange_resolution.py` covering override precedence, UTC session conversion, live `resolve_exchange`, `fetch_market_info`, and `market_timing`
 
 ### Changed
 
@@ -35,6 +37,7 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 - **Unused `logging` import in `ext/options.py`**: Removed to pass ruff lint
 - **Test imports**: `BlpInternalError` imported from `_core` (Rust) instead of `exceptions` (Python)
 - **CI fixes**: Resolved 4 Python test failures, clippy warnings (`too_many_arguments`, `SubscriptionMetrics` re-export), ruff check/format violations, cargo fmt formatting, module path for `test_markets.py`, Linux test runtime setup
+- **Exchange refdata parsing shape support**: `resolve_exchange` now handles both WIDE and LONG refdata responses by mapping `(field, value)` rows when Bloomberg returns long-shape metadata
 
 ## [1.0.0a2] - 2026-02-19
 

--- a/py-xbbg/tests/live/test_exchange_resolution.py
+++ b/py-xbbg/tests/live/test_exchange_resolution.py
@@ -8,8 +8,8 @@ def test_engine_exchange_resolution_live():
         PyEngine,
         ext_clear_exchange_override,
         ext_get_exchange_override,
-        ext_set_exchange_override,
         ext_session_times_to_utc,
+        ext_set_exchange_override,
     )
 
     start_utc, end_utc = ext_session_times_to_utc(


### PR DESCRIPTION
## Summary
- add Unreleased changelog entries for the Rust exchange/session rollout and new live exchange smoke test coverage
- include the exchange parser long-shape fix note in Unreleased/Fixes
- run and pass repo-wide Python lint (`uv run ruff check .`), including import-order cleanup in the new live test

## Verification
- `uv run ruff check .`