### PR TITLE
fix: resolve CI lint and clippy failures

### DIFF
--- a/crates/xbbg-async/src/engine/exchange.rs
+++ b/crates/xbbg-async/src/engine/exchange.rs
@@ -255,7 +255,10 @@ fn get_f64(batch: &arrow::record_batch::RecordBatch, col: &str) -> Option<f64> {
     get_long_field_value(batch, col).and_then(|s| parse_f64(&s))
 }
 
-fn get_long_field_value(batch: &arrow::record_batch::RecordBatch, field_name: &str) -> Option<String> {
+fn get_long_field_value(
+    batch: &arrow::record_batch::RecordBatch,
+    field_name: &str,
+) -> Option<String> {
     let fields = batch
         .column_by_name("field")?
         .as_any()

--- a/crates/xbbg-sys/build.rs
+++ b/crates/xbbg-sys/build.rs
@@ -27,9 +27,7 @@ impl ParseCallbacks for RenameCallback {
 fn main() {
     // Check for mutual exclusivity at build time
     #[cfg(all(feature = "mock", feature = "live"))]
-    {
-        panic!("Features 'mock' and 'live' are mutually exclusive");
-    }
+    compile_error!("Features 'mock' and 'live' are mutually exclusive");
 
     #[cfg(feature = "mock")]
     {


### PR DESCRIPTION
## Summary
- Apply `cargo fmt` to `exchange.rs` (line wrapping in `get_long_field_value` signature)
- Replace `panic!()` with `compile_error!()` in `xbbg-sys/build.rs` for mock+live mutual exclusivity check, avoiding the `unreachable_code` clippy lint

Fixes the failing `Lint (Rust)` and `Check (Linux/Windows)` CI jobs on main.