### PR TITLE
feat: add TestUtil-backed testing helpers

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [env]
-XBBG_DEV_SDK_ROOT = { value = "vendor/blpapi-sdk/3.25.12.1", relative = true }
+XBBG_DEV_SDK_ROOT = { value = "vendor/blpapi-sdk", relative = true }
 # Note: LIBCLANG_PATH is NOT set here — it varies per machine.
 # If you need bindgen locally, set it in your shell environment:
 #   Windows (VS BuildTools): set LIBCLANG_PATH=C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\Llvm\x64\bin

--- a/.github/actions/setup-blpapi-sdk/action.yml
+++ b/.github/actions/setup-blpapi-sdk/action.yml
@@ -1,0 +1,93 @@
+name: Setup Bloomberg SDK
+description: Restore or install the Bloomberg C++ SDK for the current runner OS
+
+inputs:
+  version:
+    description: Bloomberg SDK version
+    required: true
+  os:
+    description: Target runner OS (Linux, macOS, or Windows)
+    required: true
+
+outputs:
+  sdk-rel-root:
+    description: SDK root relative to the workspace
+    value: ${{ steps.paths.outputs.sdk-rel-root }}
+  lib-rel-dir:
+    description: Platform library directory relative to the workspace
+    value: ${{ steps.paths.outputs.lib-rel-dir }}
+  bin-rel-dir:
+    description: Windows runtime binary directory relative to the workspace
+    value: ${{ steps.paths.outputs.bin-rel-dir }}
+
+runs:
+  using: composite
+  steps:
+    - id: paths
+      shell: bash
+      run: |
+        sdk_rel_root="vendor/blpapi-sdk/${{ inputs.version }}"
+        case "${{ inputs.os }}" in
+          Linux)
+            lib_rel_dir="$sdk_rel_root/Linux"
+            archive_file="blpapi_cpp_${{ inputs.version }}-linux.tar.gz"
+            extractor="tar.gz"
+            ;;
+          macOS)
+            lib_rel_dir="$sdk_rel_root/Darwin"
+            archive_file="blpapi_cpp_${{ inputs.version }}-macos-arm64.tar.gz"
+            extractor="tar.gz"
+            ;;
+          Windows)
+            lib_rel_dir="$sdk_rel_root/lib"
+            archive_file="blpapi_cpp_${{ inputs.version }}-windows.zip"
+            extractor="zip"
+            ;;
+          *)
+            echo "Unsupported workflow OS input: ${{ inputs.os }}" >&2
+            exit 1
+            ;;
+        esac
+
+        echo "sdk-rel-root=$sdk_rel_root" >> "$GITHUB_OUTPUT"
+        echo "lib-rel-dir=$lib_rel_dir" >> "$GITHUB_OUTPUT"
+        echo "bin-rel-dir=$sdk_rel_root/bin" >> "$GITHUB_OUTPUT"
+        echo "archive-file=$archive_file" >> "$GITHUB_OUTPUT"
+        echo "extractor=$extractor" >> "$GITHUB_OUTPUT"
+
+    - id: cache-sdk
+      uses: actions/cache@v4
+      with:
+        path: vendor/blpapi-sdk/${{ inputs.version }}
+        key: blpapi-${{ inputs.os }}-${{ runner.arch }}-${{ inputs.version }}
+
+    - if: inputs.os != 'Windows' && steps.cache-sdk.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        archive_url="https://blpapi.bloomberg.com/download/releases/raw/files/${{ steps.paths.outputs.archive-file }}"
+        archive_path="$RUNNER_TEMP/${{ steps.paths.outputs.archive-file }}"
+        sdk_root="$GITHUB_WORKSPACE/${{ steps.paths.outputs.sdk-rel-root }}"
+        extract_root="$RUNNER_TEMP/blpapi-extract"
+        rm -rf "$sdk_root" "$extract_root"
+        mkdir -p "$(dirname "$sdk_root")" "$extract_root"
+        curl -fsSL "$archive_url" -o "$archive_path"
+        tar -xzf "$archive_path" -C "$extract_root"
+        inner_dir=$(find "$extract_root" -mindepth 1 -maxdepth 1 -type d | head -n 1)
+        mv "$inner_dir" "$sdk_root"
+
+    - if: inputs.os == 'Windows' && steps.cache-sdk.outputs.cache-hit != 'true'
+      shell: pwsh
+      run: |
+        $archiveName = '${{ steps.paths.outputs.archive-file }}'
+        $archiveUrl = "https://blpapi.bloomberg.com/download/releases/raw/files/$archiveName"
+        $archivePath = Join-Path $env:RUNNER_TEMP $archiveName
+        $extractRoot = Join-Path $env:RUNNER_TEMP 'blpapi-extract'
+        $sdkRoot = Join-Path $env:GITHUB_WORKSPACE '${{ steps.paths.outputs.sdk-rel-root }}'
+        if (Test-Path $sdkRoot) { Remove-Item -Path $sdkRoot -Recurse -Force }
+        if (Test-Path $extractRoot) { Remove-Item -Path $extractRoot -Recurse -Force }
+        New-Item -ItemType Directory -Path $extractRoot -Force | Out-Null
+        New-Item -ItemType Directory -Path (Split-Path $sdkRoot -Parent) -Force | Out-Null
+        Invoke-WebRequest -Uri $archiveUrl -OutFile $archivePath -UseBasicParsing
+        Expand-Archive -Path $archivePath -DestinationPath $extractRoot -Force
+        $innerDir = (Get-ChildItem -Path $extractRoot -Directory | Select-Object -First 1).FullName
+        Move-Item -Path $innerDir -Destination $sdkRoot -Force

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -32,7 +32,7 @@ jobs:
         id: detect
         run: |
           VERSION=$(curl -s https://blpapi.bloomberg.com/repository/releases/python/simple/blpapi/ \
-            | grep -oP 'blpapi-\K[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | sort -V | tail -1)
+            | grep -oP 'blpapi-\K[0-9]+\.[0-9]+\.[0-9]+(?:\.[0-9]+)?' | sort -V | tail -1)
           echo "Detected Bloomberg SDK version: $VERSION"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
@@ -49,26 +49,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Cache Bloomberg SDK
-        id: cache-sdk
-        uses: actions/cache@v4
-        with:
-          path: ~/blpapi
-          key: blpapi-Linux-${{ env.BLPAPI_VERSION }}
-
-      - name: Download Bloomberg SDK
-        if: steps.cache-sdk.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p "$HOME/blpapi"
-          curl -sSL "https://blpapi.bloomberg.com/download/releases/raw/files/blpapi_cpp_${BLPAPI_VERSION}-linux.tar.gz" \
-            | tar -xz -C "$HOME/blpapi" --strip-components=1
-
       - name: Setup Bloomberg SDK
+        id: sdk
+        uses: ./.github/actions/setup-blpapi-sdk
+        with:
+          version: ${{ env.BLPAPI_VERSION }}
+          os: Linux
+
+      - name: Export Bloomberg SDK env
         run: |
-          ln -sf "$HOME/blpapi/Linux" "$HOME/blpapi/lib"
-          ln -sf "$HOME/blpapi/lib/libblpapi3_64.so" "$HOME/blpapi/lib/libblpapi3.so"
-          echo "BLPAPI_ROOT=$HOME/blpapi" >> "$GITHUB_ENV"
-          echo "LD_LIBRARY_PATH=$HOME/blpapi/lib:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
+          SDK_ROOT="$GITHUB_WORKSPACE/${{ steps.sdk.outputs.sdk-rel-root }}"
+          LIB_DIR="$GITHUB_WORKSPACE/${{ steps.sdk.outputs.lib-rel-dir }}"
+          echo "BLPAPI_ROOT=$SDK_ROOT" >> "$GITHUB_ENV"
+          echo "LIBRARY_PATH=$LIB_DIR:$LIBRARY_PATH" >> "$GITHUB_ENV"
+          echo "LD_LIBRARY_PATH=$LIB_DIR:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
 
       - name: Generate bindings artifact
         run: |
@@ -238,26 +232,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Cache Bloomberg SDK
-        id: cache-sdk
-        uses: actions/cache@v4
-        with:
-          path: ~/blpapi
-          key: blpapi-Linux-${{ env.BLPAPI_VERSION }}
-
-      - name: Download Bloomberg SDK (Linux)
-        if: steps.cache-sdk.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p "$HOME/blpapi"
-          curl -sSL "https://blpapi.bloomberg.com/download/releases/raw/files/blpapi_cpp_${BLPAPI_VERSION}-linux.tar.gz" \
-            | tar -xz -C "$HOME/blpapi" --strip-components=1
-
       - name: Setup Bloomberg SDK (Linux)
+        id: sdk-linux
+        uses: ./.github/actions/setup-blpapi-sdk
+        with:
+          version: ${{ env.BLPAPI_VERSION }}
+          os: Linux
+
+      - name: Export Bloomberg SDK env (Linux)
         run: |
-          ln -sf "$HOME/blpapi/Linux" "$HOME/blpapi/lib"
-          ln -sf "$HOME/blpapi/lib/libblpapi3_64.so" "$HOME/blpapi/lib/libblpapi3.so"
-          echo "BLPAPI_ROOT=$HOME/blpapi" >> "$GITHUB_ENV"
-          echo "LD_LIBRARY_PATH=$HOME/blpapi/lib:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
+          SDK_ROOT="$GITHUB_WORKSPACE/${{ steps.sdk-linux.outputs.sdk-rel-root }}"
+          LIB_DIR="$GITHUB_WORKSPACE/${{ steps.sdk-linux.outputs.lib-rel-dir }}"
+          echo "BLPAPI_ROOT=$SDK_ROOT" >> "$GITHUB_ENV"
+          echo "LIBRARY_PATH=$LIB_DIR:$LIBRARY_PATH" >> "$GITHUB_ENV"
+          echo "LD_LIBRARY_PATH=$LIB_DIR:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
 
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -300,26 +288,20 @@ jobs:
           }
           "BLPAPI_PREGENERATED_BINDINGS=$bindingsPath" >> $env:GITHUB_ENV
 
-      - name: Cache Bloomberg SDK
-        id: cache-sdk
-        uses: actions/cache@v4
-        with:
-          path: ~/blpapi
-          key: blpapi-Windows-${{ env.BLPAPI_VERSION }}
-
-      - name: Download Bloomberg SDK (Windows)
-        if: steps.cache-sdk.outputs.cache-hit != 'true'
-        shell: pwsh
-        run: |
-          $sdkUrl = "https://blpapi.bloomberg.com/download/releases/raw/files/blpapi_cpp_${{ env.BLPAPI_VERSION }}-windows.zip"
-          Invoke-WebRequest -Uri $sdkUrl -OutFile blpapi.zip
-          Expand-Archive -Path blpapi.zip -DestinationPath $HOME/blpapi
-
       - name: Setup Bloomberg SDK (Windows)
+        id: sdk-windows
+        uses: ./.github/actions/setup-blpapi-sdk
+        with:
+          version: ${{ env.BLPAPI_VERSION }}
+          os: Windows
+
+      - name: Export Bloomberg SDK env (Windows)
         shell: pwsh
         run: |
-          $sdkPath = (Get-ChildItem $HOME/blpapi -Directory)[0].FullName
+          $sdkPath = Join-Path $env:GITHUB_WORKSPACE '${{ steps.sdk-windows.outputs.sdk-rel-root }}'
+          $binPath = Join-Path $env:GITHUB_WORKSPACE '${{ steps.sdk-windows.outputs.bin-rel-dir }}'
           "BLPAPI_ROOT=$sdkPath" >> $env:GITHUB_ENV
+          "PATH=$binPath;$env:PATH" >> $env:GITHUB_ENV
 
       - name: Cargo clippy
         shell: bash
@@ -353,26 +335,19 @@ jobs:
           test -s "$BINDINGS_PATH"
           echo "BLPAPI_PREGENERATED_BINDINGS=$BINDINGS_PATH" >> "$GITHUB_ENV"
 
-      - name: Cache Bloomberg SDK (macOS)
-        id: cache-sdk-macos
-        uses: actions/cache@v4
-        with:
-          path: ~/blpapi
-          key: blpapi-macOS-${{ env.BLPAPI_VERSION }}
-
-      - name: Download Bloomberg SDK (macOS)
-        if: steps.cache-sdk-macos.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p "$HOME/blpapi"
-          curl -sSL "https://blpapi.bloomberg.com/download/releases/raw/files/blpapi_cpp_${BLPAPI_VERSION}-macos-arm64.tar.gz" \
-            | tar -xz -C "$HOME/blpapi" --strip-components=1
-
       - name: Setup Bloomberg SDK (macOS)
+        id: sdk-macos
+        uses: ./.github/actions/setup-blpapi-sdk
+        with:
+          version: ${{ env.BLPAPI_VERSION }}
+          os: macOS
+
+      - name: Export Bloomberg SDK env (macOS)
         run: |
-          ln -sf "$HOME/blpapi/Darwin" "$HOME/blpapi/lib"
-          ln -sf "$HOME/blpapi/lib/libblpapi3_64.so" "$HOME/blpapi/lib/libblpapi3.dylib"
-          echo "BLPAPI_ROOT=$HOME/blpapi" >> "$GITHUB_ENV"
-          echo "DYLD_LIBRARY_PATH=$HOME/blpapi/lib:$DYLD_LIBRARY_PATH" >> "$GITHUB_ENV"
+          SDK_ROOT="$GITHUB_WORKSPACE/${{ steps.sdk-macos.outputs.sdk-rel-root }}"
+          LIB_DIR="$GITHUB_WORKSPACE/${{ steps.sdk-macos.outputs.lib-rel-dir }}"
+          echo "BLPAPI_ROOT=$SDK_ROOT" >> "$GITHUB_ENV"
+          echo "DYLD_LIBRARY_PATH=$LIB_DIR:$DYLD_LIBRARY_PATH" >> "$GITHUB_ENV"
 
       - name: Cargo clippy
         run: cargo clippy --workspace --all-targets --exclude datamock --exclude datamock-sys -- -D warnings
@@ -447,75 +422,55 @@ jobs:
           test -s "$BINDINGS_PATH"
           echo "BLPAPI_PREGENERATED_BINDINGS=$BINDINGS_PATH" >> "$GITHUB_ENV"
 
-      - name: Cache Bloomberg SDK (Linux)
-        if: runner.os == 'Linux'
-        id: cache-sdk-linux
-        uses: actions/cache@v4
-        with:
-          path: ~/blpapi
-          key: blpapi-Linux-${{ env.BLPAPI_VERSION }}
-
-      - name: Download Bloomberg SDK (Linux)
-        if: runner.os == 'Linux' && steps.cache-sdk-linux.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p "$HOME/blpapi"
-          curl -sSL "https://blpapi.bloomberg.com/download/releases/raw/files/blpapi_cpp_${BLPAPI_VERSION}-linux.tar.gz" \
-            | tar -xz -C "$HOME/blpapi" --strip-components=1
-
       - name: Setup Bloomberg SDK (Linux)
         if: runner.os == 'Linux'
-        run: |
-          ln -sf "$HOME/blpapi/Linux" "$HOME/blpapi/lib"
-          ln -sf "$HOME/blpapi/lib/libblpapi3_64.so" "$HOME/blpapi/lib/libblpapi3.so"
-          echo "BLPAPI_ROOT=$HOME/blpapi" >> "$GITHUB_ENV"
-          echo "LIBRARY_PATH=$HOME/blpapi/lib:$LIBRARY_PATH" >> "$GITHUB_ENV"
-          echo "LD_LIBRARY_PATH=$HOME/blpapi/lib:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
-
-      - name: Cache Bloomberg SDK (Windows)
-        if: runner.os == 'Windows'
-        id: cache-sdk-windows
-        uses: actions/cache@v4
+        id: sdk-linux
+        uses: ./.github/actions/setup-blpapi-sdk
         with:
-          path: ~/blpapi
-          key: blpapi-Windows-${{ env.BLPAPI_VERSION }}
+          version: ${{ env.BLPAPI_VERSION }}
+          os: Linux
 
-      - name: Download Bloomberg SDK (Windows)
-        if: runner.os == 'Windows' && steps.cache-sdk-windows.outputs.cache-hit != 'true'
-        shell: pwsh
+      - name: Export Bloomberg SDK env (Linux)
+        if: runner.os == 'Linux'
         run: |
-          $sdkUrl = "https://blpapi.bloomberg.com/download/releases/raw/files/blpapi_cpp_${{ env.BLPAPI_VERSION }}-windows.zip"
-          Invoke-WebRequest -Uri $sdkUrl -OutFile blpapi.zip
-          Expand-Archive -Path blpapi.zip -DestinationPath $HOME/blpapi
+          SDK_ROOT="$GITHUB_WORKSPACE/${{ steps.sdk-linux.outputs.sdk-rel-root }}"
+          LIB_DIR="$GITHUB_WORKSPACE/${{ steps.sdk-linux.outputs.lib-rel-dir }}"
+          echo "BLPAPI_ROOT=$SDK_ROOT" >> "$GITHUB_ENV"
+          echo "LIBRARY_PATH=$LIB_DIR:$LIBRARY_PATH" >> "$GITHUB_ENV"
+          echo "LD_LIBRARY_PATH=$LIB_DIR:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
 
       - name: Setup Bloomberg SDK (Windows)
         if: runner.os == 'Windows'
+        id: sdk-windows
+        uses: ./.github/actions/setup-blpapi-sdk
+        with:
+          version: ${{ env.BLPAPI_VERSION }}
+          os: Windows
+
+      - name: Export Bloomberg SDK env (Windows)
+        if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          $sdkPath = (Get-ChildItem $HOME/blpapi -Directory)[0].FullName
+          $sdkPath = Join-Path $env:GITHUB_WORKSPACE '${{ steps.sdk-windows.outputs.sdk-rel-root }}'
+          $binPath = Join-Path $env:GITHUB_WORKSPACE '${{ steps.sdk-windows.outputs.bin-rel-dir }}'
           "BLPAPI_ROOT=$sdkPath" >> $env:GITHUB_ENV
-
-      - name: Cache Bloomberg SDK (macOS)
-        if: runner.os == 'macOS'
-        id: cache-sdk-macos
-        uses: actions/cache@v4
-        with:
-          path: ~/blpapi
-          key: blpapi-macOS-${{ env.BLPAPI_VERSION }}
-
-      - name: Download Bloomberg SDK (macOS)
-        if: runner.os == 'macOS' && steps.cache-sdk-macos.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p "$HOME/blpapi"
-          curl -sSL "https://blpapi.bloomberg.com/download/releases/raw/files/blpapi_cpp_${BLPAPI_VERSION}-macos-arm64.tar.gz" \
-            | tar -xz -C "$HOME/blpapi" --strip-components=1
+          "PATH=$binPath;$env:PATH" >> $env:GITHUB_ENV
 
       - name: Setup Bloomberg SDK (macOS)
         if: runner.os == 'macOS'
+        id: sdk-macos
+        uses: ./.github/actions/setup-blpapi-sdk
+        with:
+          version: ${{ env.BLPAPI_VERSION }}
+          os: macOS
+
+      - name: Export Bloomberg SDK env (macOS)
+        if: runner.os == 'macOS'
         run: |
-          ln -sf "$HOME/blpapi/Darwin" "$HOME/blpapi/lib"
-          ln -sf "$HOME/blpapi/lib/libblpapi3_64.so" "$HOME/blpapi/lib/libblpapi3.dylib"
-          echo "BLPAPI_ROOT=$HOME/blpapi" >> "$GITHUB_ENV"
-          echo "DYLD_LIBRARY_PATH=$HOME/blpapi/lib:$DYLD_LIBRARY_PATH" >> "$GITHUB_ENV"
+          SDK_ROOT="$GITHUB_WORKSPACE/${{ steps.sdk-macos.outputs.sdk-rel-root }}"
+          LIB_DIR="$GITHUB_WORKSPACE/${{ steps.sdk-macos.outputs.lib-rel-dir }}"
+          echo "BLPAPI_ROOT=$SDK_ROOT" >> "$GITHUB_ENV"
+          echo "DYLD_LIBRARY_PATH=$LIB_DIR:$DYLD_LIBRARY_PATH" >> "$GITHUB_ENV"
 
       - name: Setup Python ${{ matrix.python }}
         uses: actions/setup-python@v5
@@ -569,52 +524,38 @@ jobs:
           name: wheel-${{ matrix.os }}-py${{ matrix.python }}
           path: dist
 
-      - name: Cache Bloomberg SDK (Linux)
-        if: runner.os == 'Linux'
-        id: cache-sdk-linux
-        uses: actions/cache@v4
-        with:
-          path: ~/blpapi
-          key: blpapi-Linux-${{ env.BLPAPI_VERSION }}
-
-      - name: Download Bloomberg SDK (Linux)
-        if: runner.os == 'Linux' && steps.cache-sdk-linux.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p "$HOME/blpapi"
-          curl -sSL "https://blpapi.bloomberg.com/download/releases/raw/files/blpapi_cpp_${BLPAPI_VERSION}-linux.tar.gz" \
-            | tar -xz -C "$HOME/blpapi" --strip-components=1
-
       - name: Setup Bloomberg SDK (Linux)
         if: runner.os == 'Linux'
-        run: |
-          ln -sf "$HOME/blpapi/Linux" "$HOME/blpapi/lib"
-          ln -sf "$HOME/blpapi/lib/libblpapi3_64.so" "$HOME/blpapi/lib/libblpapi3.so"
-          echo "BLPAPI_ROOT=$HOME/blpapi" >> "$GITHUB_ENV"
-          echo "LIBRARY_PATH=$HOME/blpapi/lib:$LIBRARY_PATH" >> "$GITHUB_ENV"
-          echo "LD_LIBRARY_PATH=$HOME/blpapi/lib:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
-
-      - name: Cache Bloomberg SDK (macOS)
-        if: runner.os == 'macOS'
-        id: cache-sdk-macos
-        uses: actions/cache@v4
+        id: sdk-linux
+        uses: ./.github/actions/setup-blpapi-sdk
         with:
-          path: ~/blpapi
-          key: blpapi-macOS-${{ env.BLPAPI_VERSION }}
+          version: ${{ env.BLPAPI_VERSION }}
+          os: Linux
 
-      - name: Download Bloomberg SDK (macOS)
-        if: runner.os == 'macOS' && steps.cache-sdk-macos.outputs.cache-hit != 'true'
+      - name: Export Bloomberg SDK env (Linux)
+        if: runner.os == 'Linux'
         run: |
-          mkdir -p "$HOME/blpapi"
-          curl -sSL "https://blpapi.bloomberg.com/download/releases/raw/files/blpapi_cpp_${BLPAPI_VERSION}-macos-arm64.tar.gz" \
-            | tar -xz -C "$HOME/blpapi" --strip-components=1
+          SDK_ROOT="$GITHUB_WORKSPACE/${{ steps.sdk-linux.outputs.sdk-rel-root }}"
+          LIB_DIR="$GITHUB_WORKSPACE/${{ steps.sdk-linux.outputs.lib-rel-dir }}"
+          echo "BLPAPI_ROOT=$SDK_ROOT" >> "$GITHUB_ENV"
+          echo "LIBRARY_PATH=$LIB_DIR:$LIBRARY_PATH" >> "$GITHUB_ENV"
+          echo "LD_LIBRARY_PATH=$LIB_DIR:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
 
       - name: Setup Bloomberg SDK (macOS)
         if: runner.os == 'macOS'
+        id: sdk-macos
+        uses: ./.github/actions/setup-blpapi-sdk
+        with:
+          version: ${{ env.BLPAPI_VERSION }}
+          os: macOS
+
+      - name: Export Bloomberg SDK env (macOS)
+        if: runner.os == 'macOS'
         run: |
-          ln -sf "$HOME/blpapi/Darwin" "$HOME/blpapi/lib"
-          ln -sf "$HOME/blpapi/lib/libblpapi3_64.so" "$HOME/blpapi/lib/libblpapi3.dylib"
-          echo "BLPAPI_ROOT=$HOME/blpapi" >> "$GITHUB_ENV"
-          echo "DYLD_LIBRARY_PATH=$HOME/blpapi/lib:$DYLD_LIBRARY_PATH" >> "$GITHUB_ENV"
+          SDK_ROOT="$GITHUB_WORKSPACE/${{ steps.sdk-macos.outputs.sdk-rel-root }}"
+          LIB_DIR="$GITHUB_WORKSPACE/${{ steps.sdk-macos.outputs.lib-rel-dir }}"
+          echo "BLPAPI_ROOT=$SDK_ROOT" >> "$GITHUB_ENV"
+          echo "DYLD_LIBRARY_PATH=$LIB_DIR:$DYLD_LIBRARY_PATH" >> "$GITHUB_ENV"
 
       - name: Install blpapi from Bloomberg
         run: uv pip install --system --index-url https://blpapi.bloomberg.com/repository/releases/python/simple/ blpapi
@@ -663,26 +604,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Cache Bloomberg SDK
-        id: cache-sdk
-        uses: actions/cache@v4
-        with:
-          path: ~/blpapi
-          key: blpapi-Linux-${{ env.BLPAPI_VERSION }}
-
-      - name: Download Bloomberg SDK (Linux)
-        if: steps.cache-sdk.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p "$HOME/blpapi"
-          curl -sSL "https://blpapi.bloomberg.com/download/releases/raw/files/blpapi_cpp_${BLPAPI_VERSION}-linux.tar.gz" \
-            | tar -xz -C "$HOME/blpapi" --strip-components=1
-
       - name: Setup Bloomberg SDK (Linux)
+        id: sdk-linux
+        uses: ./.github/actions/setup-blpapi-sdk
+        with:
+          version: ${{ env.BLPAPI_VERSION }}
+          os: Linux
+
+      - name: Export Bloomberg SDK env (Linux)
         run: |
-          ln -sf "$HOME/blpapi/Linux" "$HOME/blpapi/lib"
-          ln -sf "$HOME/blpapi/lib/libblpapi3_64.so" "$HOME/blpapi/lib/libblpapi3.so"
-          echo "BLPAPI_ROOT=$HOME/blpapi" >> "$GITHUB_ENV"
-          echo "LD_LIBRARY_PATH=$HOME/blpapi/lib:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
+          SDK_ROOT="$GITHUB_WORKSPACE/${{ steps.sdk-linux.outputs.sdk-rel-root }}"
+          LIB_DIR="$GITHUB_WORKSPACE/${{ steps.sdk-linux.outputs.lib-rel-dir }}"
+          echo "BLPAPI_ROOT=$SDK_ROOT" >> "$GITHUB_ENV"
+          echo "LIBRARY_PATH=$LIB_DIR:$LIBRARY_PATH" >> "$GITHUB_ENV"
+          echo "LD_LIBRARY_PATH=$LIB_DIR:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
 
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -711,26 +646,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Cache Bloomberg SDK
-        id: cache-sdk
-        uses: actions/cache@v4
-        with:
-          path: ~/blpapi
-          key: blpapi-Linux-${{ env.BLPAPI_VERSION }}
-
-      - name: Download Bloomberg SDK (Linux)
-        if: steps.cache-sdk.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p "$HOME/blpapi"
-          curl -sSL "https://blpapi.bloomberg.com/download/releases/raw/files/blpapi_cpp_${BLPAPI_VERSION}-linux.tar.gz" \
-            | tar -xz -C "$HOME/blpapi" --strip-components=1
-
       - name: Setup Bloomberg SDK (Linux)
+        id: sdk-linux
+        uses: ./.github/actions/setup-blpapi-sdk
+        with:
+          version: ${{ env.BLPAPI_VERSION }}
+          os: Linux
+
+      - name: Export Bloomberg SDK env (Linux)
         run: |
-          ln -sf "$HOME/blpapi/Linux" "$HOME/blpapi/lib"
-          ln -sf "$HOME/blpapi/lib/libblpapi3_64.so" "$HOME/blpapi/lib/libblpapi3.so"
-          echo "BLPAPI_ROOT=$HOME/blpapi" >> "$GITHUB_ENV"
-          echo "LD_LIBRARY_PATH=$HOME/blpapi/lib:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
+          SDK_ROOT="$GITHUB_WORKSPACE/${{ steps.sdk-linux.outputs.sdk-rel-root }}"
+          LIB_DIR="$GITHUB_WORKSPACE/${{ steps.sdk-linux.outputs.lib-rel-dir }}"
+          echo "BLPAPI_ROOT=$SDK_ROOT" >> "$GITHUB_ENV"
+          echo "LIBRARY_PATH=$LIB_DIR:$LIBRARY_PATH" >> "$GITHUB_ENV"
+          echo "LD_LIBRARY_PATH=$LIB_DIR:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
 
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -766,26 +695,20 @@ jobs:
         with:
           fetch-depth: 0  # Full history for baseline
 
-      - name: Cache Bloomberg SDK
-        id: cache-sdk
-        uses: actions/cache@v4
-        with:
-          path: ~/blpapi
-          key: blpapi-Linux-${{ env.BLPAPI_VERSION }}
-
-      - name: Download Bloomberg SDK (Linux)
-        if: steps.cache-sdk.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p "$HOME/blpapi"
-          curl -sSL "https://blpapi.bloomberg.com/download/releases/raw/files/blpapi_cpp_${BLPAPI_VERSION}-linux.tar.gz" \
-            | tar -xz -C "$HOME/blpapi" --strip-components=1
-
       - name: Setup Bloomberg SDK (Linux)
+        id: sdk-linux
+        uses: ./.github/actions/setup-blpapi-sdk
+        with:
+          version: ${{ env.BLPAPI_VERSION }}
+          os: Linux
+
+      - name: Export Bloomberg SDK env (Linux)
         run: |
-          ln -sf "$HOME/blpapi/Linux" "$HOME/blpapi/lib"
-          ln -sf "$HOME/blpapi/lib/libblpapi3_64.so" "$HOME/blpapi/lib/libblpapi3.so"
-          echo "BLPAPI_ROOT=$HOME/blpapi" >> "$GITHUB_ENV"
-          echo "LD_LIBRARY_PATH=$HOME/blpapi/lib:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
+          SDK_ROOT="$GITHUB_WORKSPACE/${{ steps.sdk-linux.outputs.sdk-rel-root }}"
+          LIB_DIR="$GITHUB_WORKSPACE/${{ steps.sdk-linux.outputs.lib-rel-dir }}"
+          echo "BLPAPI_ROOT=$SDK_ROOT" >> "$GITHUB_ENV"
+          echo "LIBRARY_PATH=$LIB_DIR:$LIBRARY_PATH" >> "$GITHUB_ENV"
+          echo "LD_LIBRARY_PATH=$LIB_DIR:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
 
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -912,26 +835,20 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Cache Bloomberg SDK
-        id: cache-sdk
-        uses: actions/cache@v4
-        with:
-          path: ~/blpapi
-          key: blpapi-Linux-${{ env.BLPAPI_VERSION }}
-
-      - name: Download Bloomberg SDK
-        if: steps.cache-sdk.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p "$HOME/blpapi"
-          curl -sSL "https://blpapi.bloomberg.com/download/releases/raw/files/blpapi_cpp_${BLPAPI_VERSION}-linux.tar.gz" \
-            | tar -xz -C "$HOME/blpapi" --strip-components=1
-
       - name: Setup Bloomberg SDK
+        id: sdk-linux
+        uses: ./.github/actions/setup-blpapi-sdk
+        with:
+          version: ${{ env.BLPAPI_VERSION }}
+          os: Linux
+
+      - name: Export Bloomberg SDK env
         run: |
-          ln -sf "$HOME/blpapi/Linux" "$HOME/blpapi/lib"
-          ln -sf "$HOME/blpapi/lib/libblpapi3_64.so" "$HOME/blpapi/lib/libblpapi3.so"
-          echo "BLPAPI_ROOT=$HOME/blpapi" >> "$GITHUB_ENV"
-          echo "LD_LIBRARY_PATH=$HOME/blpapi/lib:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
+          SDK_ROOT="$GITHUB_WORKSPACE/${{ steps.sdk-linux.outputs.sdk-rel-root }}"
+          LIB_DIR="$GITHUB_WORKSPACE/${{ steps.sdk-linux.outputs.lib-rel-dir }}"
+          echo "BLPAPI_ROOT=$SDK_ROOT" >> "$GITHUB_ENV"
+          echo "LIBRARY_PATH=$LIB_DIR:$LIBRARY_PATH" >> "$GITHUB_ENV"
+          echo "LD_LIBRARY_PATH=$LIB_DIR:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
 
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -31,7 +31,7 @@ jobs:
         id: detect
         run: |
           VERSION=$(curl -s https://blpapi.bloomberg.com/repository/releases/python/simple/blpapi/ \
-            | grep -oP 'blpapi-\K[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | sort -V | tail -1)
+            | grep -oP 'blpapi-\K[0-9]+\.[0-9]+\.[0-9]+(?:\.[0-9]+)?' | sort -V | tail -1)
           echo "Detected Bloomberg SDK version: $VERSION"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
@@ -48,26 +48,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Cache Bloomberg SDK
-        id: cache-sdk
-        uses: actions/cache@v4
-        with:
-          path: ~/blpapi
-          key: blpapi-Linux-${{ env.BLPAPI_VERSION }}
-
-      - name: Download Bloomberg SDK
-        if: steps.cache-sdk.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p "$HOME/blpapi"
-          curl -sSL "https://blpapi.bloomberg.com/download/releases/raw/files/blpapi_cpp_${BLPAPI_VERSION}-linux.tar.gz" \
-            | tar -xz -C "$HOME/blpapi" --strip-components=1
-
       - name: Setup Bloomberg SDK
+        id: sdk
+        uses: ./.github/actions/setup-blpapi-sdk
+        with:
+          version: ${{ env.BLPAPI_VERSION }}
+          os: Linux
+
+      - name: Export Bloomberg SDK env
         run: |
-          ln -sf "$HOME/blpapi/Linux" "$HOME/blpapi/lib"
-          ln -sf "$HOME/blpapi/lib/libblpapi3_64.so" "$HOME/blpapi/lib/libblpapi3.so"
-          echo "BLPAPI_ROOT=$HOME/blpapi" >> "$GITHUB_ENV"
-          echo "LD_LIBRARY_PATH=$HOME/blpapi/lib:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
+          SDK_ROOT="$GITHUB_WORKSPACE/${{ steps.sdk.outputs.sdk-rel-root }}"
+          LIB_DIR="$GITHUB_WORKSPACE/${{ steps.sdk.outputs.lib-rel-dir }}"
+          echo "BLPAPI_ROOT=$SDK_ROOT" >> "$GITHUB_ENV"
+          echo "LIBRARY_PATH=$LIB_DIR:$LIBRARY_PATH" >> "$GITHUB_ENV"
+          echo "LD_LIBRARY_PATH=$LIB_DIR:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
 
       - name: Generate bindings artifact
         run: |
@@ -138,75 +132,55 @@ jobs:
           test -s "$BINDINGS_PATH"
           echo "BLPAPI_PREGENERATED_BINDINGS=$BINDINGS_PATH" >> "$GITHUB_ENV"
 
-      - name: Cache Bloomberg SDK (Linux)
-        if: runner.os == 'Linux'
-        id: cache-sdk-linux
-        uses: actions/cache@v4
-        with:
-          path: ~/blpapi
-          key: blpapi-Linux-${{ env.BLPAPI_VERSION }}
-
-      - name: Download Bloomberg SDK (Linux)
-        if: runner.os == 'Linux' && steps.cache-sdk-linux.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p "$HOME/blpapi"
-          curl -sSL "https://blpapi.bloomberg.com/download/releases/raw/files/blpapi_cpp_${BLPAPI_VERSION}-linux.tar.gz" \
-            | tar -xz -C "$HOME/blpapi" --strip-components=1
-
       - name: Setup Bloomberg SDK (Linux)
         if: runner.os == 'Linux'
-        run: |
-          ln -sf "$HOME/blpapi/Linux" "$HOME/blpapi/lib"
-          ln -sf "$HOME/blpapi/lib/libblpapi3_64.so" "$HOME/blpapi/lib/libblpapi3.so"
-          echo "BLPAPI_ROOT=$HOME/blpapi" >> "$GITHUB_ENV"
-          echo "LIBRARY_PATH=$HOME/blpapi/lib:$LIBRARY_PATH" >> "$GITHUB_ENV"
-          echo "LD_LIBRARY_PATH=$HOME/blpapi/lib:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
-
-      - name: Cache Bloomberg SDK (Windows)
-        if: runner.os == 'Windows'
-        id: cache-sdk-windows
-        uses: actions/cache@v4
+        id: sdk-linux
+        uses: ./.github/actions/setup-blpapi-sdk
         with:
-          path: ~/blpapi
-          key: blpapi-Windows-${{ env.BLPAPI_VERSION }}
+          version: ${{ env.BLPAPI_VERSION }}
+          os: Linux
 
-      - name: Download Bloomberg SDK (Windows)
-        if: runner.os == 'Windows' && steps.cache-sdk-windows.outputs.cache-hit != 'true'
-        shell: pwsh
+      - name: Export Bloomberg SDK env (Linux)
+        if: runner.os == 'Linux'
         run: |
-          $sdkUrl = "https://blpapi.bloomberg.com/download/releases/raw/files/blpapi_cpp_${{ env.BLPAPI_VERSION }}-windows.zip"
-          Invoke-WebRequest -Uri $sdkUrl -OutFile blpapi.zip
-          Expand-Archive -Path blpapi.zip -DestinationPath $HOME/blpapi
+          SDK_ROOT="$GITHUB_WORKSPACE/${{ steps.sdk-linux.outputs.sdk-rel-root }}"
+          LIB_DIR="$GITHUB_WORKSPACE/${{ steps.sdk-linux.outputs.lib-rel-dir }}"
+          echo "BLPAPI_ROOT=$SDK_ROOT" >> "$GITHUB_ENV"
+          echo "LIBRARY_PATH=$LIB_DIR:$LIBRARY_PATH" >> "$GITHUB_ENV"
+          echo "LD_LIBRARY_PATH=$LIB_DIR:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
 
       - name: Setup Bloomberg SDK (Windows)
         if: runner.os == 'Windows'
+        id: sdk-windows
+        uses: ./.github/actions/setup-blpapi-sdk
+        with:
+          version: ${{ env.BLPAPI_VERSION }}
+          os: Windows
+
+      - name: Export Bloomberg SDK env (Windows)
+        if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          $sdkPath = (Get-ChildItem $HOME/blpapi -Directory)[0].FullName
+          $sdkPath = Join-Path $env:GITHUB_WORKSPACE '${{ steps.sdk-windows.outputs.sdk-rel-root }}'
+          $binPath = Join-Path $env:GITHUB_WORKSPACE '${{ steps.sdk-windows.outputs.bin-rel-dir }}'
           "BLPAPI_ROOT=$sdkPath" >> $env:GITHUB_ENV
-
-      - name: Cache Bloomberg SDK (macOS)
-        if: runner.os == 'macOS'
-        id: cache-sdk-macos
-        uses: actions/cache@v4
-        with:
-          path: ~/blpapi
-          key: blpapi-macOS-${{ env.BLPAPI_VERSION }}
-
-      - name: Download Bloomberg SDK (macOS)
-        if: runner.os == 'macOS' && steps.cache-sdk-macos.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p "$HOME/blpapi"
-          curl -sSL "https://blpapi.bloomberg.com/download/releases/raw/files/blpapi_cpp_${BLPAPI_VERSION}-macos-arm64.tar.gz" \
-            | tar -xz -C "$HOME/blpapi" --strip-components=1
+          "PATH=$binPath;$env:PATH" >> $env:GITHUB_ENV
 
       - name: Setup Bloomberg SDK (macOS)
         if: runner.os == 'macOS'
+        id: sdk-macos
+        uses: ./.github/actions/setup-blpapi-sdk
+        with:
+          version: ${{ env.BLPAPI_VERSION }}
+          os: macOS
+
+      - name: Export Bloomberg SDK env (macOS)
+        if: runner.os == 'macOS'
         run: |
-          ln -sf "$HOME/blpapi/Darwin" "$HOME/blpapi/lib"
-          ln -sf "$HOME/blpapi/lib/libblpapi3_64.so" "$HOME/blpapi/lib/libblpapi3.dylib"
-          echo "BLPAPI_ROOT=$HOME/blpapi" >> "$GITHUB_ENV"
-          echo "DYLD_LIBRARY_PATH=$HOME/blpapi/lib:$DYLD_LIBRARY_PATH" >> "$GITHUB_ENV"
+          SDK_ROOT="$GITHUB_WORKSPACE/${{ steps.sdk-macos.outputs.sdk-rel-root }}"
+          LIB_DIR="$GITHUB_WORKSPACE/${{ steps.sdk-macos.outputs.lib-rel-dir }}"
+          echo "BLPAPI_ROOT=$SDK_ROOT" >> "$GITHUB_ENV"
+          echo "DYLD_LIBRARY_PATH=$LIB_DIR:$DYLD_LIBRARY_PATH" >> "$GITHUB_ENV"
 
       - name: Setup Python ${{ matrix.python }}
         uses: actions/setup-python@v5

--- a/.github/workflows/semantic_version.yml
+++ b/.github/workflows/semantic_version.yml
@@ -280,29 +280,23 @@ jobs:
       id: sdk
       run: |
         VERSION=$(curl -s https://blpapi.bloomberg.com/repository/releases/python/simple/blpapi/ \
-          | grep -oP 'blpapi-\K[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | sort -V | tail -1)
+          | grep -oP 'blpapi-\K[0-9]+\.[0-9]+\.[0-9]+(?:\.[0-9]+)?' | sort -V | tail -1)
         echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-    - name: Cache Bloomberg SDK
-      id: cache-sdk
-      uses: actions/cache@v4
-      with:
-        path: ~/blpapi
-        key: blpapi-Linux-${{ steps.sdk.outputs.version }}
-
-    - name: Download Bloomberg SDK
-      if: steps.cache-sdk.outputs.cache-hit != 'true'
-      run: |
-        mkdir -p "$HOME/blpapi"
-        curl -sSL "https://blpapi.bloomberg.com/download/releases/raw/files/blpapi_cpp_${{ steps.sdk.outputs.version }}-linux.tar.gz" \
-          | tar -xz -C "$HOME/blpapi" --strip-components=1
-
     - name: Setup Bloomberg SDK
+      id: sdk-setup
+      uses: ./.github/actions/setup-blpapi-sdk
+      with:
+        version: ${{ steps.sdk.outputs.version }}
+        os: Linux
+
+    - name: Export Bloomberg SDK env
       run: |
-        ln -sf "$HOME/blpapi/Linux" "$HOME/blpapi/lib"
-        ln -sf "$HOME/blpapi/lib/libblpapi3_64.so" "$HOME/blpapi/lib/libblpapi3.so"
-        echo "BLPAPI_ROOT=$HOME/blpapi" >> "$GITHUB_ENV"
-        echo "LD_LIBRARY_PATH=$HOME/blpapi/lib:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
+        SDK_ROOT="$GITHUB_WORKSPACE/${{ steps.sdk-setup.outputs.sdk-rel-root }}"
+        LIB_DIR="$GITHUB_WORKSPACE/${{ steps.sdk-setup.outputs.lib-rel-dir }}"
+        echo "BLPAPI_ROOT=$SDK_ROOT" >> "$GITHUB_ENV"
+        echo "LIBRARY_PATH=$LIB_DIR:$LIBRARY_PATH" >> "$GITHUB_ENV"
+        echo "LD_LIBRARY_PATH=$LIB_DIR:$LD_LIBRARY_PATH" >> "$GITHUB_ENV"
 
     - name: Setup Rust
       uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ env.local
 # Sisyphus
 .sisyphus/
 
+# Local orchestration scratch space
+.omx/
+
 # Benchmark dependencies (isolated Python env for benchmarks)
 .benchmark_deps/
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,8 +21,11 @@ Thank you for your interest in contributing to xbbg!
 
 2. Set up the Bloomberg SDK:
    ```bash
-   # Set BLPAPI_ROOT to your SDK location
-   export BLPAPI_ROOT=/path/to/blpapi_cpp_x.x.x.x
+   # macOS/Linux
+   bash ./scripts/sdktool.sh
+
+   # Windows PowerShell
+   # .\scripts\sdktool.ps1
    ```
 
 3. Install dependencies and build:

--- a/README.md
+++ b/README.md
@@ -1658,13 +1658,15 @@ blp.fieldInfo(['PX_LAST', 'VOLUME'])  # See data types & descriptions
 Create venv and install dependencies:
 
 ```bash
-# Set Bloomberg SDK path (required for building the Rust extension)
-export BLPAPI_ROOT=/path/to/blpapi_cpp_x.x.x.x  # Linux/macOS
-# $env:BLPAPI_ROOT = "C:\path\to\blpapi_cpp_x.x.x.x"  # Windows PowerShell
+# Install the Bloomberg SDK into vendor/blpapi-sdk/ and let xbbg discover it
+bash ./scripts/sdktool.sh               # macOS/Linux
+# .\scripts\sdktool.ps1                # Windows PowerShell
 
 # Install all dev dependencies (uses uv dependency-groups)
 uv sync
 ```
+
+If you already manage the SDK yourself, you can still set `BLPAPI_ROOT` manually.
 
 ### Adding Dependencies
 

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -117,11 +117,9 @@ Go to **GitHub Actions** > **Bump Version and Create Release** > **Run workflow*
 ### Build Locally
 
 ```bash
-# Set Bloomberg SDK path (required for wheel builds)
-# Windows PowerShell:
-$env:BLPAPI_ROOT = "$PWD\vendor\blpapi-sdk\3.25.12.1"
-# Linux/macOS:
-export BLPAPI_ROOT=$PWD/vendor/blpapi-sdk/3.25.12.1
+# Install the SDK into vendor/blpapi-sdk/ and let the build discover it
+bash ./scripts/sdktool.sh
+# Windows PowerShell: .\scripts\sdktool.ps1
 
 # Build wheel (includes Rust extension)
 uv build

--- a/crates/blpapi-sys/README.md
+++ b/crates/blpapi-sys/README.md
@@ -52,13 +52,20 @@ By default, bindings are generated with bindgen at build time.
 
 **Dev (quickest)**: run the SDK tool from the repo root, then build:
 
+```bash
+bash ./scripts/sdktool.sh
+```
+
 ```powershell
 .\scripts\sdktool.ps1            # downloads, extracts, sets .env
 ```
 
 This writes `XBBG_DEV_SDK_ROOT=vendor/blpapi-sdk/<version>` to `.env`.
 
-**Dev (manual)**: set `XBBG_DEV_SDK_ROOT` to the SDK root, then build the workspace.
+`blpapi-sys` can also resolve a versioned SDK beneath `vendor/blpapi-sdk/` directly,
+so CI and local builds do not need to pin a specific SDK path in `.cargo/config.toml`.
+
+**Dev (manual)**: set `XBBG_DEV_SDK_ROOT` or `BLPAPI_ROOT` to the SDK root, then build the workspace.
 
 **CI build**: set `BLPAPI_ROOT` or `BLPAPI_INCLUDE_DIR`/`BLPAPI_LIB_DIR`.
 

--- a/crates/blpapi-sys/build.rs
+++ b/crates/blpapi-sys/build.rs
@@ -27,21 +27,9 @@ fn main() {
     }
 
     // Determine library base name based on target platform and architecture
-    let lib_name = env::var("BLPAPI_LINK_LIB_NAME").ok().unwrap_or_else(|| {
-        let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
-        let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
-
-        if target_os == "windows" {
-            if target_arch == "x86" {
-                "blpapi3_32".to_string()
-            } else {
-                "blpapi3_64".to_string()
-            }
-        } else {
-            // Linux uses blpapi3 (symlinked from blpapi3_64)
-            "blpapi3".to_string()
-        }
-    });
+    let lib_name = env::var("BLPAPI_LINK_LIB_NAME")
+        .ok()
+        .unwrap_or_else(|| detect_link_lib_name(&lib_dir));
 
     // Emit link type
     if want_static {
@@ -142,7 +130,7 @@ fn resolve_include_and_lib_dirs() -> Result<(PathBuf, PathBuf), String> {
     // 2) Root
     if let Some(root) = env::var_os("BLPAPI_ROOT") {
         let root = PathBuf::from(root);
-        let (inc, lib) = derive_include_lib(&root)?;
+        let (inc, lib) = resolve_sdk_layout(&root)?;
         validate_header_exists(&inc)?;
         return Ok((inc, lib));
     }
@@ -162,7 +150,7 @@ fn resolve_include_and_lib_dirs() -> Result<(PathBuf, PathBuf), String> {
                 root = workspace_root.join(&root);
             }
         }
-        let (inc, lib) = derive_include_lib(&root)?;
+        let (inc, lib) = resolve_sdk_layout(&root)?;
         validate_header_exists(&inc)?;
         return Ok((inc, lib));
     }
@@ -170,39 +158,252 @@ fn resolve_include_and_lib_dirs() -> Result<(PathBuf, PathBuf), String> {
     Err("Cannot locate Bloomberg SDK. Set BLPAPI_INCLUDE_DIR/BLPAPI_LIB_DIR, or BLPAPI_ROOT, or XBBG_DEV_SDK_ROOT".into())
 }
 
-fn derive_include_lib(root: &Path) -> Result<(PathBuf, PathBuf), String> {
-    let inc = root.join("include");
-    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+fn resolve_sdk_layout(root: &Path) -> Result<(PathBuf, PathBuf), String> {
+    let mut last_error = None;
 
-    // Try common layouts:
-    // <root>/include and <root>/lib
-    let lib1 = root.join("lib");
-    if inc.is_dir() && lib1.is_dir() {
-        return Ok((inc, lib1));
+    for candidate in candidate_sdk_roots(root)? {
+        match derive_include_lib(&candidate) {
+            Ok(layout) => return Ok(layout),
+            Err(err) => last_error = Some(err),
+        }
     }
 
-    // Windows: check architecture-specific lib directories
-    let win_lib_subdir = if target_arch == "x86" {
-        "win32"
+    if let Some(err) = last_error {
+        Err(err)
     } else {
-        "win64"
-    };
-    let lib2 = root.join("lib").join(win_lib_subdir);
-    if inc.is_dir() && lib2.is_dir() {
-        return Ok((inc, lib2));
+        Err(format!("No SDK candidates found under {}", root.display()))
+    }
+}
+
+fn candidate_sdk_roots(root: &Path) -> Result<Vec<PathBuf>, String> {
+    if !root.is_dir() {
+        return Err(format!(
+            "SDK root does not exist or is not a directory: {}",
+            root.display()
+        ));
     }
 
-    // Fallback: try capitalized Include/Lib (rare)
-    let inc3 = root.join("Include");
-    let lib3 = root.join("Lib");
-    if inc3.is_dir() && lib3.is_dir() {
-        return Ok((inc3, lib3));
+    let mut roots = vec![root.to_path_buf()];
+
+    if let Some(active_root) = active_sdk_root(root) {
+        if !roots.iter().any(|existing| existing == &active_root) {
+            roots.push(active_root);
+        }
+    }
+
+    let children = sorted_child_dirs(root)?;
+
+    for child in &children {
+        if !roots.iter().any(|existing| existing == child) {
+            roots.push(child.clone());
+        }
+    }
+
+    for child in children {
+        for grandchild in sorted_child_dirs(&child)? {
+            if !roots.iter().any(|existing| existing == &grandchild) {
+                roots.push(grandchild);
+            }
+        }
+    }
+
+    Ok(roots)
+}
+
+fn active_sdk_root(root: &Path) -> Option<PathBuf> {
+    let workspace_root = workspace_root()?;
+    let env_file = workspace_root.join(".env");
+    let contents = fs::read_to_string(env_file).ok()?;
+
+    for line in contents.lines() {
+        let trimmed = line.trim();
+        if let Some(value) = trimmed.strip_prefix("XBBG_DEV_SDK_ROOT=") {
+            let candidate = if Path::new(value).is_absolute() {
+                PathBuf::from(value)
+            } else {
+                workspace_root.join(value)
+            };
+
+            if candidate.starts_with(root) && candidate.is_dir() {
+                return Some(candidate);
+            }
+        }
+    }
+
+    None
+}
+
+fn workspace_root() -> Option<PathBuf> {
+    let manifest_dir = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR")?);
+    Some(manifest_dir.parent()?.parent()?.to_path_buf())
+}
+
+fn sorted_child_dirs(root: &Path) -> Result<Vec<PathBuf>, String> {
+    let mut entries = Vec::new();
+
+    for entry in fs::read_dir(root).map_err(|e| e.to_string())? {
+        let entry = entry.map_err(|e| e.to_string())?;
+        let path = entry.path();
+        if path.is_dir() {
+            entries.push(path);
+        }
+    }
+
+    entries.sort_by(|a, b| compare_sdk_dir_names(a.file_name(), b.file_name()));
+    Ok(entries)
+}
+
+fn compare_sdk_dir_names(
+    a: Option<&std::ffi::OsStr>,
+    b: Option<&std::ffi::OsStr>,
+) -> std::cmp::Ordering {
+    let a_name = a.and_then(|value| value.to_str()).unwrap_or_default();
+    let b_name = b.and_then(|value| value.to_str()).unwrap_or_default();
+
+    match (
+        parse_version_components(a_name),
+        parse_version_components(b_name),
+    ) {
+        (Some(a_version), Some(b_version)) => b_version.cmp(&a_version),
+        (Some(_), None) => std::cmp::Ordering::Less,
+        (None, Some(_)) => std::cmp::Ordering::Greater,
+        (None, None) => a_name.cmp(b_name),
+    }
+}
+
+fn parse_version_components(value: &str) -> Option<Vec<u32>> {
+    let mut parts = Vec::new();
+
+    for piece in value.split('.') {
+        if piece.is_empty() {
+            return None;
+        }
+        parts.push(piece.parse().ok()?);
+    }
+
+    if parts.len() >= 3 && parts.len() <= 4 {
+        Some(parts)
+    } else {
+        None
+    }
+}
+
+fn derive_include_lib(root: &Path) -> Result<(PathBuf, PathBuf), String> {
+    let include_candidates = [root.join("include"), root.join("Include")];
+
+    for include_dir in include_candidates {
+        if !include_dir.is_dir() || validate_header_exists(&include_dir).is_err() {
+            continue;
+        }
+
+        for lib_dir in library_dir_candidates(root) {
+            if lib_dir.is_dir() && contains_linkable_blpapi_lib(&lib_dir) {
+                return Ok((include_dir.clone(), lib_dir));
+            }
+        }
     }
 
     Err(format!(
-        "Could not derive include/lib under {}. Expected include/ and lib/ (or lib/{win_lib_subdir}/).",
+        "Could not derive include/lib under {}.",
         root.display()
     ))
+}
+
+fn library_dir_candidates(root: &Path) -> Vec<PathBuf> {
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+    let mut candidates = vec![
+        root.join("lib"),
+        root.join("Lib"),
+        root.join("lib64"),
+        root.join("bin"),
+    ];
+
+    if target_os == "windows" {
+        let win_lib_subdir = if target_arch == "x86" {
+            "win32"
+        } else {
+            "win64"
+        };
+        candidates.push(root.join("lib").join(win_lib_subdir));
+    } else if target_os == "linux" {
+        candidates.push(root.join("Linux"));
+        candidates.push(root.join("linux"));
+    } else if target_os == "macos" {
+        candidates.push(root.join("Darwin"));
+        candidates.push(root.join("darwin"));
+        candidates.push(root.join("MacOS"));
+        candidates.push(root.join("macos"));
+    }
+
+    candidates
+}
+
+fn contains_linkable_blpapi_lib(lib_dir: &Path) -> bool {
+    expected_library_files()
+        .iter()
+        .any(|file_name| lib_dir.join(file_name).is_file())
+}
+
+fn detect_link_lib_name(lib_dir: &Path) -> String {
+    if lib_dir.join("blpapi3_64.lib").is_file()
+        || lib_dir.join("blpapi3_64.dll").is_file()
+        || lib_dir.join("libblpapi3_64.so").is_file()
+        || lib_dir.join("libblpapi3_64.dylib").is_file()
+        || lib_dir.join("libblpapi3_64.a").is_file()
+    {
+        return "blpapi3_64".to_string();
+    }
+
+    if lib_dir.join("blpapi3_32.lib").is_file()
+        || lib_dir.join("blpapi3_32.dll").is_file()
+        || lib_dir.join("libblpapi3_32.so").is_file()
+        || lib_dir.join("libblpapi3_32.dylib").is_file()
+        || lib_dir.join("libblpapi3_32.a").is_file()
+    {
+        return "blpapi3_32".to_string();
+    }
+
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+    if target_os == "windows" {
+        if target_arch == "x86" {
+            "blpapi3_32".to_string()
+        } else {
+            "blpapi3_64".to_string()
+        }
+    } else {
+        "blpapi3".to_string()
+    }
+}
+
+fn expected_library_files() -> Vec<&'static str> {
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+
+    if target_os == "windows" {
+        if target_arch == "x86" {
+            vec!["blpapi3_32.lib", "blpapi3_32.dll"]
+        } else {
+            vec!["blpapi3_64.lib", "blpapi3_64.dll"]
+        }
+    } else if target_os == "macos" {
+        vec![
+            "libblpapi3.so",
+            "libblpapi3_64.so",
+            "libblpapi3.dylib",
+            "libblpapi3_64.dylib",
+            "libblpapi3.a",
+            "libblpapi3_64.a",
+        ]
+    } else {
+        vec![
+            "libblpapi3.so",
+            "libblpapi3_64.so",
+            "libblpapi3.a",
+            "libblpapi3_64.a",
+        ]
+    }
 }
 
 fn validate_header_exists(include_dir: &Path) -> Result<(), String> {

--- a/docker/README.md
+++ b/docker/README.md
@@ -30,14 +30,10 @@ podman run --rm \
   -e BLPAPI_BINDINGS_EXPORT_PATH=/work/target/ci-bindings/bindings.rs \
   xbbg-ci:local \
   bash -lc '
-    BLPAPI_VERSION=3.25.12.1
-    mkdir -p /tmp/blpapi
-    curl -sSL "https://blpapi.bloomberg.com/download/releases/raw/files/blpapi_cpp_${BLPAPI_VERSION}-linux.tar.gz" \
-      | tar -xz -C /tmp/blpapi --strip-components=1
-    ln -sf /tmp/blpapi/Linux /tmp/blpapi/lib
-    ln -sf /tmp/blpapi/lib/libblpapi3_64.so /tmp/blpapi/lib/libblpapi3.so
-    export BLPAPI_ROOT=/tmp/blpapi
-    export LD_LIBRARY_PATH=/tmp/blpapi/lib:$LD_LIBRARY_PATH
+    BLPAPI_VERSION=${BLPAPI_VERSION:-3.26.2.1}
+    bash ./scripts/sdktool.sh --version "$BLPAPI_VERSION" --no-set-active
+    export BLPAPI_ROOT=/work/vendor/blpapi-sdk/$BLPAPI_VERSION
+    export LD_LIBRARY_PATH=/work/vendor/blpapi-sdk/$BLPAPI_VERSION/Linux:$LD_LIBRARY_PATH
     cargo build -p blpapi-sys
   '
 ```
@@ -50,14 +46,10 @@ podman run --rm \
   -w /work \
   xbbg-ci:local \
   bash -lc '
-    BLPAPI_VERSION=3.25.12.1
-    mkdir -p /tmp/blpapi
-    curl -sSL "https://blpapi.bloomberg.com/download/releases/raw/files/blpapi_cpp_${BLPAPI_VERSION}-linux.tar.gz" \
-      | tar -xz -C /tmp/blpapi --strip-components=1
-    ln -sf /tmp/blpapi/Linux /tmp/blpapi/lib
-    ln -sf /tmp/blpapi/lib/libblpapi3_64.so /tmp/blpapi/lib/libblpapi3.so
-    export BLPAPI_ROOT=/tmp/blpapi
-    export LD_LIBRARY_PATH=/tmp/blpapi/lib:$LD_LIBRARY_PATH
+    BLPAPI_VERSION=${BLPAPI_VERSION:-3.26.2.1}
+    bash ./scripts/sdktool.sh --version "$BLPAPI_VERSION" --no-set-active
+    export BLPAPI_ROOT=/work/vendor/blpapi-sdk/$BLPAPI_VERSION
+    export LD_LIBRARY_PATH=/work/vendor/blpapi-sdk/$BLPAPI_VERSION/Linux:$LD_LIBRARY_PATH
     cargo clippy --workspace --all-targets --exclude datamock --exclude datamock-sys -- -D warnings
   '
 ```

--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -37,7 +37,12 @@ xbbg requires the Bloomberg C++ SDK shared library. You have several options:
     - Linux: `~/blp/DAPI` or `/opt/bloomberg/DAPI`
   </TabItem>
   <TabItem label="Manual SDK">
-    Set the `BLPAPI_ROOT` environment variable:
+    For local development from this repo, use the bundled helper:
+    ```bash
+    bash ./scripts/sdktool.sh
+    ```
+
+    Or set the `BLPAPI_ROOT` environment variable manually:
     ```bash
     export BLPAPI_ROOT=/path/to/blpapi_cpp_3.x.x.x
     ```

--- a/py-xbbg/src/xbbg/_exports.py
+++ b/py-xbbg/src/xbbg/_exports.py
@@ -65,6 +65,7 @@ EXCEPTION_EXPORTS = (
 MODULE_EXPORTS = (
     "ext",
     "markets",
+    "testing",
 )
 
 BACKEND_EXPORTS = (

--- a/py-xbbg/src/xbbg/testing.py
+++ b/py-xbbg/src/xbbg/testing.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+import importlib
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+from . import blp
+
+pa = importlib.import_module("pyarrow")
+
+
+def _nw_module():
+    return importlib.import_module("narwhals.stable.v1")
+
+
+def _require_blpapi():
+    try:
+        import blpapi  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise ImportError(
+            "xbbg.testing requires the Bloomberg Python package for TestUtil-backed helpers. "
+            "Install `blpapi` to use create_mock_event()/deserialize_service() helpers."
+        ) from exc
+    return blpapi
+
+
+def create_mock_event(event_type: int):
+    blpapi = _require_blpapi()
+    return blpapi.test.createEvent(event_type)
+
+
+def deserialize_service(service_xml: str):
+    blpapi = _require_blpapi()
+    return blpapi.test.deserializeService(service_xml)
+
+
+def get_admin_message_definition(message_name: str | Any):
+    blpapi = _require_blpapi()
+    if isinstance(message_name, str):
+        message_name = blpapi.Name(message_name)
+    return blpapi.test.getAdminMessageDefinition(message_name)
+
+
+def append_message_dict(event, element_def, payload: Mapping[str, Any], properties: Any | None = None):
+    blpapi = _require_blpapi()
+    formatter = blpapi.test.appendMessage(event, element_def, properties)
+    formatter.formatMessageDict(dict(payload))
+    return formatter
+
+
+def _coerce_blpapi_service(service: str | Any, service_xml: str | None):
+    if service_xml is not None:
+        return deserialize_service(service_xml)
+
+    blpapi = _require_blpapi()
+    if hasattr(service, "getOperation"):
+        return service
+    if not isinstance(service, str):
+        raise TypeError("service must be a Bloomberg Service, service URI string, or XML-backed service")
+
+    raise ValueError(
+        "A raw service URI cannot be converted to a TestUtil service definition by itself. "
+        "Pass `service_xml=` or a pre-built `blpapi.Service` when you need a real mock event."
+    )
+
+
+def _build_message_properties(
+    *,
+    correlation_ids: Sequence[Any] | None = None,
+    request_id: str | None = None,
+    service: Any | None = None,
+):
+    if correlation_ids is None and request_id is None and service is None:
+        return None
+
+    blpapi = _require_blpapi()
+    props = blpapi.test.MessageProperties()
+    if correlation_ids:
+        props.setCorrelationIds(list(correlation_ids))
+    if request_id:
+        props.setRequestId(request_id)
+    if service is not None:
+        props.setService(service)
+    return props
+
+
+def _stringify_value(value: Any) -> str | None:
+    if value is None:
+        return None
+    return str(value)
+
+
+def _reference_rows(data: Mapping[str, Mapping[str, Any]]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for ticker, fields in data.items():
+        for field_name, value in fields.items():
+            rows.append(
+                {
+                    "ticker": ticker,
+                    "field": field_name,
+                    "value": _stringify_value(value),
+                }
+            )
+    return rows
+
+
+def _historical_rows(data: Mapping[str, Any]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for ticker, ticker_payload in data.items():
+        if isinstance(ticker_payload, Mapping):
+            for date_value, fields in ticker_payload.items():
+                if not isinstance(fields, Mapping):
+                    raise TypeError("HistoricalDataRequest mapping values must be field mappings")
+                for field_name, value in fields.items():
+                    rows.append(
+                        {
+                            "ticker": ticker,
+                            "date": str(date_value),
+                            "field": field_name,
+                            "value": _stringify_value(value),
+                        }
+                    )
+        elif isinstance(ticker_payload, Sequence) and not isinstance(ticker_payload, (str, bytes, bytearray)):
+            for entry in ticker_payload:
+                if not isinstance(entry, Mapping):
+                    raise TypeError("HistoricalDataRequest row entries must be mappings")
+                date_value = entry.get("date")
+                for key, value in entry.items():
+                    if key == "date":
+                        continue
+                    rows.append(
+                        {
+                            "ticker": ticker,
+                            "date": str(date_value),
+                            "field": key,
+                            "value": _stringify_value(value),
+                        }
+                    )
+        else:
+            raise TypeError("Unsupported HistoricalDataRequest payload shape")
+    return rows
+
+
+def _rows_from_operation(operation: str, data: Any) -> list[dict[str, Any]]:
+    if isinstance(data, Sequence) and not isinstance(data, (str, bytes, bytearray)):
+        rows = [dict(row) for row in data]
+        if not all(isinstance(row, Mapping) for row in data):
+            raise TypeError("Explicit mock rows must be mappings")
+        return rows
+
+    if not isinstance(data, Mapping):
+        raise TypeError("Mock response data must be a mapping or a list of row mappings")
+
+    if operation == "ReferenceDataRequest":
+        return _reference_rows(data)
+    if operation == "HistoricalDataRequest":
+        return _historical_rows(data)
+
+    raise ValueError(
+        f"No default row builder for operation {operation!r}. Pass an explicit list of row mappings for this operation."
+    )
+
+
+def _table_from_rows(rows: Sequence[Mapping[str, Any]]) -> Any:
+    if not rows:
+        return pa.table({})
+    return pa.Table.from_pylist([dict(row) for row in rows])
+
+
+@dataclass(slots=True)
+class MockResponse:
+    service: str
+    operation: str
+    table: Any
+    event: Any | None = None
+    request_operation: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def matches(self, params_dict: Mapping[str, Any]) -> bool:
+        if params_dict.get("service") != self.service:
+            return False
+
+        actual_operation = params_dict.get("request_operation") or params_dict.get("operation")
+        expected_operation = self.request_operation or self.operation
+        return actual_operation == expected_operation
+
+
+def create_mock_response(
+    *,
+    service: str | Any,
+    operation: str,
+    data: Any,
+    service_xml: str | None = None,
+    event_type: int | None = None,
+    correlation_ids: Sequence[Any] | None = None,
+    request_id: str | None = None,
+) -> MockResponse:
+    if isinstance(service, str):
+        service_name = service
+    else:
+        service_name = service.name()
+    rows = _rows_from_operation(operation, data)
+    table = _table_from_rows(rows)
+
+    event = None
+    service_obj: Any | None = None
+    if service_xml is not None:
+        service_obj = _coerce_blpapi_service(service, service_xml)
+    elif not isinstance(service, str):
+        service_obj = service
+
+    if service_obj is not None:
+        op = service_obj.getOperation(operation)
+        element_def = op.getResponseDefinitionAt(0)
+        event = create_mock_event(event_type or _require_blpapi().Event.RESPONSE)
+        props = _build_message_properties(
+            correlation_ids=correlation_ids,
+            request_id=request_id,
+            service=service_obj,
+        )
+        append_message_dict(event, element_def, data, props)
+
+    return MockResponse(
+        service=service_name,
+        operation=operation,
+        table=table,
+        event=event,
+        metadata={"rows": rows},
+    )
+
+
+def _coerce_mock_table(value: MockResponse | Any | Sequence[Mapping[str, Any]]) -> Any:
+    if isinstance(value, MockResponse):
+        return value.table
+    if isinstance(value, pa.Table):
+        return value
+    if isinstance(value, pa.RecordBatch):
+        return pa.Table.from_batches([value])
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return _table_from_rows(value)
+    raise TypeError("Unsupported mock response value")
+
+
+class mock_engine:
+    def __init__(
+        self,
+        responses: Sequence[MockResponse | Any | Sequence[Mapping[str, Any]]],
+        *,
+        strict: bool = True,
+    ) -> None:
+        self._responses = list(responses)
+        self._strict = strict
+        self._middleware = None
+
+    def _pop_match(self, params_dict: Mapping[str, Any]):
+        for index, candidate in enumerate(self._responses):
+            if isinstance(candidate, MockResponse):
+                if candidate.matches(params_dict):
+                    return self._responses.pop(index)
+            else:
+                if index == 0:
+                    return self._responses.pop(index)
+        return None
+
+    async def _handle(self, context: blp.RequestContext, call_next):
+        match = self._pop_match(context.params_dict)
+        if match is None:
+            if self._strict:
+                raise LookupError(f"No mock response matched {context.params.service}::{context.params.operation}")
+            return await call_next(context)
+
+        table = _coerce_mock_table(match)
+        batch = next(iter(table.to_batches()), None)
+        if batch is None:
+            batch = pa.record_batch([], names=[])
+
+        context.metadata["mocked"] = True
+        if isinstance(match, MockResponse):
+            context.metadata["mock_response"] = match
+        context.batch = batch
+        context.table = table
+        context.elapsed_ms = 0.0
+
+        nw_df = _nw_module().from_native(table)
+        context.frame = blp._convert_backend(nw_df, context.backend)
+        return context.frame
+
+    def __enter__(self):
+        async def middleware(context: blp.RequestContext, call_next):
+            return await self._handle(context, call_next)
+
+        self._middleware = middleware
+        blp.add_middleware(middleware)
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if self._middleware is not None:
+            try:
+                blp.remove_middleware(self._middleware)
+            finally:
+                self._middleware = None
+
+
+__all__ = [
+    "MockResponse",
+    "append_message_dict",
+    "create_mock_event",
+    "create_mock_response",
+    "deserialize_service",
+    "get_admin_message_definition",
+    "mock_engine",
+]

--- a/py-xbbg/src/xbbg/testing.py
+++ b/py-xbbg/src/xbbg/testing.py
@@ -1,8 +1,10 @@
+"""Testing helpers for non-live xbbg request and response flows."""
+
 from __future__ import annotations
 
-import importlib
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
+import importlib
 from typing import Any
 
 from . import blp
@@ -53,7 +55,6 @@ def _coerce_blpapi_service(service: str | Any, service_xml: str | None):
     if service_xml is not None:
         return deserialize_service(service_xml)
 
-    blpapi = _require_blpapi()
     if hasattr(service, "getOperation"):
         return service
     if not isinstance(service, str):
@@ -170,6 +171,8 @@ def _table_from_rows(rows: Sequence[Mapping[str, Any]]) -> Any:
 
 @dataclass(slots=True)
 class MockResponse:
+    """Container for a canned xbbg response and optional Bloomberg event."""
+
     service: str
     operation: str
     table: Any
@@ -243,6 +246,8 @@ def _coerce_mock_table(value: MockResponse | Any | Sequence[Mapping[str, Any]]) 
 
 
 class mock_engine:
+    """Middleware context manager that serves canned responses."""
+
     def __init__(
         self,
         responses: Sequence[MockResponse | Any | Sequence[Mapping[str, Any]]],

--- a/py-xbbg/tests/test_testing.py
+++ b/py-xbbg/tests/test_testing.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from typing import Any
+
+import pytest
+
+import xbbg
+from xbbg import blp
+from xbbg.testing import (
+    append_message_dict,
+    create_mock_event,
+    create_mock_response,
+    deserialize_service,
+    mock_engine,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_blp_state():
+    old_config = blp._config
+    old_engine = blp._engine
+    old_middleware = blp.get_middleware()
+    blp.clear_middleware()
+    blp._config = None
+    blp._engine = None
+    try:
+        yield
+    finally:
+        blp.clear_middleware()
+        blp.set_middleware(old_middleware)
+        blp._config = old_config
+        blp._engine = old_engine
+
+
+def test_create_mock_response_builds_reference_rows_without_blpapi():
+    response = create_mock_response(
+        service="//blp/refdata",
+        operation="ReferenceDataRequest",
+        data={"AAPL US Equity": {"PX_LAST": 254.23, "VOLUME": 100}},
+    )
+
+    assert response.service == "//blp/refdata"
+    assert response.operation == "ReferenceDataRequest"
+    assert response.event is None
+    assert response.table.to_pylist() == [
+        {"ticker": "AAPL US Equity", "field": "PX_LAST", "value": "254.23"},
+        {"ticker": "AAPL US Equity", "field": "VOLUME", "value": "100"},
+    ]
+
+
+def test_mock_engine_intercepts_bdp_requests(monkeypatch):
+    class UnexpectedEngine:
+        async def resolve_field_types(self, fields, overrides, default_type):
+            return {field: (overrides or {}).get(field, default_type) for field in fields}
+
+        async def request(self, _params_dict):
+            raise AssertionError("live engine should not be called")
+
+    monkeypatch.setattr(blp, "_get_engine", lambda *args, **kwargs: UnexpectedEngine())
+
+    response = create_mock_response(
+        service="//blp/refdata",
+        operation="ReferenceDataRequest",
+        data={"AAPL US Equity": {"PX_LAST": 254.23}},
+    )
+
+    with mock_engine([response]):
+        result = blp.bdp("AAPL US Equity", "PX_LAST")
+
+    native = result.to_native()
+    assert native.to_pylist() == [
+        {"ticker": "AAPL US Equity", "field": "PX_LAST", "value": "254.23"},
+    ]
+
+
+def test_mock_engine_restores_middleware_after_exit():
+    before = blp.get_middleware()
+    response = create_mock_response(
+        service="//blp/refdata",
+        operation="ReferenceDataRequest",
+        data={"AAPL US Equity": {"PX_LAST": 254.23}},
+    )
+
+    with mock_engine([response]):
+        assert len(blp.get_middleware()) == len(before) + 1
+
+    assert blp.get_middleware() == before
+
+
+def test_mock_engine_raises_for_unmatched_request(monkeypatch):
+    class UnexpectedEngine:
+        async def resolve_field_types(self, fields, overrides, default_type):
+            return {field: (overrides or {}).get(field, default_type) for field in fields}
+
+        async def request(self, _params_dict):
+            raise AssertionError("live engine should not be called")
+
+    monkeypatch.setattr(blp, "_get_engine", lambda *args, **kwargs: UnexpectedEngine())
+
+    response = create_mock_response(
+        service="//blp/refdata",
+        operation="HistoricalDataRequest",
+        data={"AAPL US Equity": {"2024-01-01": {"PX_LAST": 254.23}}},
+    )
+
+    with mock_engine([response]):
+        with pytest.raises(LookupError, match="No mock response matched"):
+            blp.bdp("AAPL US Equity", "PX_LAST")
+
+
+def test_testutil_wrappers_use_blpapi_when_available(monkeypatch):
+    calls: list[tuple[Any, ...]] = []
+
+    class FakeFormatter:
+        def formatMessageDict(self, payload):
+            calls.append(("format", dict(payload)))
+
+    fake_test = types.SimpleNamespace(
+        createEvent=lambda event_type: calls.append(("createEvent", event_type)) or {"event_type": event_type},
+        deserializeService=lambda xml: calls.append(("deserializeService", xml)) or {"xml": xml},
+        appendMessage=lambda event, element_def, properties=None: (
+            calls.append(("appendMessage", event, element_def, properties)) or FakeFormatter()
+        ),
+        getAdminMessageDefinition=lambda name: calls.append(("adminDef", name)) or {"name": name},
+    )
+    fake_blpapi = types.SimpleNamespace(
+        test=fake_test, Name=lambda value: ("Name", value), Event=types.SimpleNamespace(RESPONSE=5)
+    )
+    monkeypatch.setitem(sys.modules, "blpapi", fake_blpapi)
+
+    event = create_mock_event(5)
+    service = deserialize_service("<xml />")
+    element_def = ("element", "def")
+    formatter = append_message_dict(event, element_def, {"value": 1})
+
+    assert service == {"xml": "<xml />"}
+    assert formatter is not None
+    assert calls == [
+        ("createEvent", 5),
+        ("deserializeService", "<xml />"),
+        ("appendMessage", {"event_type": 5}, element_def, None),
+        ("format", {"value": 1}),
+    ]
+
+
+def test_testing_module_is_importable_from_package():
+    assert "testing" not in xbbg.__all__ or hasattr(xbbg, "__all__")
+    module = __import__("xbbg.testing", fromlist=["mock_engine"])
+    assert hasattr(module, "mock_engine")

--- a/py-xbbg/tests/test_testing.py
+++ b/py-xbbg/tests/test_testing.py
@@ -111,6 +111,33 @@ def test_mock_engine_raises_for_unmatched_request(monkeypatch):
             blp.bdp("AAPL US Equity", "PX_LAST")
 
 
+def test_mock_engine_intercepts_generic_request(monkeypatch):
+    class UnexpectedEngine:
+        async def request(self, _params_dict):
+            raise AssertionError("live engine should not be called")
+
+    monkeypatch.setattr(blp, "_get_engine", lambda *args, **kwargs: UnexpectedEngine())
+
+    response = create_mock_response(
+        service="//blp/refdata",
+        operation="ReferenceDataRequest",
+        data={"IBM US Equity": {"PX_LAST": 123.45}},
+    )
+
+    with mock_engine([response]):
+        result = blp.request(
+            service="//blp/refdata",
+            operation="ReferenceDataRequest",
+            securities=["IBM US Equity"],
+            fields=["PX_LAST"],
+        )
+
+    native = result.to_native()
+    assert native.to_pylist() == [
+        {"ticker": "IBM US Equity", "field": "PX_LAST", "value": "123.45"},
+    ]
+
+
 def test_testutil_wrappers_use_blpapi_when_available(monkeypatch):
     calls: list[tuple[Any, ...]] = []
 

--- a/py-xbbg/tests/test_testing.py
+++ b/py-xbbg/tests/test_testing.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import sys
 import types
 from typing import Any
@@ -106,9 +105,8 @@ def test_mock_engine_raises_for_unmatched_request(monkeypatch):
         data={"AAPL US Equity": {"2024-01-01": {"PX_LAST": 254.23}}},
     )
 
-    with mock_engine([response]):
-        with pytest.raises(LookupError, match="No mock response matched"):
-            blp.bdp("AAPL US Equity", "PX_LAST")
+    with mock_engine([response]), pytest.raises(LookupError, match="No mock response matched"):
+        blp.bdp("AAPL US Equity", "PX_LAST")
 
 
 def test_mock_engine_intercepts_generic_request(monkeypatch):

--- a/scripts/sdktool.ps1
+++ b/scripts/sdktool.ps1
@@ -96,6 +96,45 @@ $VendorBase = Join-Path (Join-Path $RepoRoot 'vendor') 'blpapi-sdk'
 $CacheDir   = Join-Path $VendorBase '.cache'
 $EnvFile    = Join-Path $RepoRoot '.env'
 
+function Get-PlatformInfo {
+    param([string]$Version)
+
+    $windows = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)
+    $linux   = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Linux)
+    $macos   = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::OSX)
+    $arch    = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant()
+
+    if ($windows) {
+        return @{
+            Label           = 'Windows'
+            ArchiveFileName = "blpapi_cpp_${Version}-windows.zip"
+            Extractor       = 'zip'
+        }
+    }
+
+    if ($linux) {
+        return @{
+            Label           = 'Linux'
+            ArchiveFileName = "blpapi_cpp_${Version}-linux.tar.gz"
+            Extractor       = 'tar.gz'
+        }
+    }
+
+    if ($macos) {
+        if ($arch -eq 'arm64') {
+            return @{
+                Label           = 'macOS arm64'
+                ArchiveFileName = "blpapi_cpp_${Version}-macos-arm64.tar.gz"
+                Extractor       = 'tar.gz'
+            }
+        }
+
+        throw "Unsupported macOS architecture '$arch'. Add a Bloomberg archive mapping for this architecture before using sdktool.ps1."
+    }
+
+    throw 'Unsupported operating system for sdktool.ps1.'
+}
+
 # ---------------------------------------------------------------------------
 # Helper: resolve the latest SDK version from Bloomberg's Python Simple Index
 # ---------------------------------------------------------------------------
@@ -155,7 +194,7 @@ function Get-ActiveSdkVersion {
 
     if ($line) {
         # Extract version from path like vendor/blpapi-sdk/3.25.12.1
-        if ($line -match 'vendor/blpapi-sdk/([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)') {
+        if ($line -match 'vendor/blpapi-sdk/([0-9]+\.[0-9]+\.[0-9]+(?:\.[0-9]+)?)') {
             return $Matches[1]
         }
     }
@@ -248,12 +287,11 @@ if ($PSCmdlet.ParameterSetName -eq 'Remove') {
     Remove-Item -Path $VersionDir -Recurse -Force
     Write-Host ('  Removed: {0}' -f $VersionDir) -ForegroundColor DarkGray
 
-    # Remove cached zip if present
-    $ZipFileName = "blpapi_cpp_${Version}-windows.zip"
-    $ZipPath = Join-Path $CacheDir $ZipFileName
-    if (Test-Path $ZipPath) {
-        Remove-Item -Path $ZipPath -Force
-        Write-Host ('  Removed: {0}' -f $ZipFileName) -ForegroundColor DarkGray
+    $CachedArchives = @(Get-ChildItem -Path $CacheDir -File -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -like "blpapi_cpp_${Version}-*" })
+    foreach ($archive in $CachedArchives) {
+        Remove-Item -Path $archive.FullName -Force
+        Write-Host ('  Removed: {0}' -f $archive.Name) -ForegroundColor DarkGray
     }
 
     # Clear .env if this was the active version
@@ -293,8 +331,8 @@ if ($PSCmdlet.ParameterSetName -eq 'List') {
 
     $activeVersion = Get-ActiveSdkVersion
     $installed = Get-ChildItem -Path $VendorBase -Directory -ErrorAction SilentlyContinue |
-                 Where-Object { $_.Name -match '^\d+\.\d+\.\d+\.\d+$' } |
-                 Sort-Object Name
+                 Where-Object { $_.Name -match '^\d+\.\d+\.\d+(\.\d+)?$' } |
+                  Sort-Object Name
 
     if (-not $installed) {
         Write-Host 'No SDK versions installed.' -ForegroundColor Yellow
@@ -332,14 +370,16 @@ elseif ($Version -notmatch '^\d+\.\d+\.\d+(\.\d+)?$') {
     throw "Invalid version format: '$Version'. Expected format: X.Y.Z or X.Y.Z.W (e.g., 3.25.12.1)"
 }
 
-$VersionDir  = Join-Path $VendorBase $Version
-$ZipFileName = "blpapi_cpp_${Version}-windows.zip"
-$ZipPath     = Join-Path $CacheDir $ZipFileName
-$DownloadUrl = "https://blpapi.bloomberg.com/download/releases/raw/files/$ZipFileName"
+$VersionDir      = Join-Path $VendorBase $Version
+$Platform        = Get-PlatformInfo -Version $Version
+$ArchiveFileName = $Platform.ArchiveFileName
+$ArchivePath     = Join-Path $CacheDir $ArchiveFileName
+$DownloadUrl     = "https://blpapi.bloomberg.com/download/releases/raw/files/$ArchiveFileName"
 
 Write-Host ''
 Write-Host "Bloomberg C++ SDK" -ForegroundColor Cyan
 Write-Host "  Version : $Version"
+Write-Host "  Platform: $($Platform.Label)"
 Write-Host "  Target  : $VersionDir"
 Write-Host ''
 
@@ -369,25 +409,25 @@ foreach ($dir in @($VendorBase, $CacheDir)) {
 }
 
 # --- Download (skip if cached) ---------------------------------------------
-if ((Test-Path $ZipPath) -and -not $Force) {
-    Write-Host ('[OK] Using cached download: {0}' -f $ZipFileName) -ForegroundColor Green
+if ((Test-Path $ArchivePath) -and -not $Force) {
+    Write-Host ('[OK] Using cached download: {0}' -f $ArchiveFileName) -ForegroundColor Green
 } else {
-    Write-Host ('[..] Downloading {0} ...' -f $ZipFileName) -ForegroundColor Yellow
+    Write-Host ('[..] Downloading {0} ...' -f $ArchiveFileName) -ForegroundColor Yellow
     Write-Host "     URL: $DownloadUrl" -ForegroundColor DarkGray
 
     try {
         $ProgressPreference = 'SilentlyContinue'   # drastically speeds up Invoke-WebRequest
-        Invoke-WebRequest -Uri $DownloadUrl -OutFile $ZipPath -UseBasicParsing
+        Invoke-WebRequest -Uri $DownloadUrl -OutFile $ArchivePath -UseBasicParsing
         $ProgressPreference = 'Continue'
     }
     catch {
         # Clean up partial download
-        if (Test-Path $ZipPath) { Remove-Item $ZipPath -Force }
+        if (Test-Path $ArchivePath) { Remove-Item $ArchivePath -Force }
         Write-Host ('[FAIL] Download failed: {0}' -f $_) -ForegroundColor Red
         throw "Failed to download Bloomberg C++ SDK v${Version}. Verify the version number and your network connection."
     }
 
-    $sizeKB = [math]::Round((Get-Item $ZipPath).Length / 1KB)
+    $sizeKB = [math]::Round((Get-Item $ArchivePath).Length / 1KB)
     Write-Host ('[OK] Downloaded ({0} KB)' -f $sizeKB) -ForegroundColor Green
 }
 
@@ -399,24 +439,31 @@ $TempExtract = Join-Path $VendorBase ".tmp-extract-$Version"
 try {
     # Clean up any leftover temp directory from a prior failed run
     if (Test-Path $TempExtract) { Remove-Item $TempExtract -Recurse -Force }
+    New-Item -ItemType Directory -Path $TempExtract -Force | Out-Null
 
-    Expand-Archive -Path $ZipPath -DestinationPath $TempExtract -Force
-
-    # The zip contains a top-level folder like blpapi_cpp_3.25.12.1-windows/
-    # We need to move its contents into vendor/blpapi-sdk/<version>/
-    $innerDirs = @(Get-ChildItem -Path $TempExtract -Directory)
-
-    if ($innerDirs.Count -eq 1) {
-        # Single top-level directory inside the zip — move it to the version dir
-        Move-Item -Path $innerDirs[0].FullName -Destination $VersionDir -Force
+    if ($Platform.Extractor -eq 'zip') {
+        Expand-Archive -Path $ArchivePath -DestinationPath $TempExtract -Force
     }
-    elseif ($innerDirs.Count -eq 0) {
-        # Contents are at the root of the zip (no wrapper directory)
+    else {
+        & tar -xzf $ArchivePath -C $TempExtract
+        if ($LASTEXITCODE -ne 0) {
+            throw 'tar extraction failed.'
+        }
+    }
+
+    $innerEntries = @(Get-ChildItem -Path $TempExtract -Force)
+
+    if ($innerEntries.Count -eq 1 -and $innerEntries[0].PSIsContainer) {
+        Move-Item -Path $innerEntries[0].FullName -Destination $VersionDir -Force
+    }
+    elseif ($innerEntries.Count -eq 0) {
         Move-Item -Path $TempExtract -Destination $VersionDir -Force
     }
     else {
-        # Multiple top-level entries — wrap them as-is
-        Move-Item -Path $TempExtract -Destination $VersionDir -Force
+        New-Item -ItemType Directory -Path $VersionDir -Force | Out-Null
+        foreach ($entry in $innerEntries) {
+            Move-Item -Path $entry.FullName -Destination $VersionDir -Force
+        }
     }
 }
 catch {
@@ -447,6 +494,12 @@ Write-Host "Bloomberg C++ SDK v$Version added and ready." -ForegroundColor Cyan
 
 $includeDir = Join-Path $VersionDir 'include'
 $libDir     = Join-Path $VersionDir 'lib'
+$linuxDir   = Join-Path $VersionDir 'Linux'
+$darwinDir  = Join-Path $VersionDir 'Darwin'
+$binDir     = Join-Path $VersionDir 'bin'
 if (Test-Path $includeDir) { Write-Host "  include/ : $includeDir" -ForegroundColor DarkGray }
 if (Test-Path $libDir)     { Write-Host "  lib/     : $libDir" -ForegroundColor DarkGray }
+if (Test-Path $linuxDir)   { Write-Host "  Linux/   : $linuxDir" -ForegroundColor DarkGray }
+if (Test-Path $darwinDir)  { Write-Host "  Darwin/  : $darwinDir" -ForegroundColor DarkGray }
+if (Test-Path $binDir)     { Write-Host "  bin/     : $binDir" -ForegroundColor DarkGray }
 Write-Host ''

--- a/scripts/sdktool.sh
+++ b/scripts/sdktool.sh
@@ -1,0 +1,336 @@
+#!/usr/bin/env sh
+set -eu
+
+usage() {
+    printf '%s\n' \
+        "Usage: ./scripts/sdktool.sh [VERSION] [--no-set-active] [--force]" \
+        "       ./scripts/sdktool.sh --remove VERSION" \
+        "       ./scripts/sdktool.sh --list" \
+        "       ./scripts/sdktool.sh --clean-cache"
+}
+
+die() {
+    printf 'error: %s\n' "$1" >&2
+    exit 1
+}
+
+note() {
+    printf '%s\n' "$1"
+}
+
+resolve_python() {
+    if command -v python3 >/dev/null 2>&1; then
+        command -v python3
+        return
+    fi
+
+    if command -v python >/dev/null 2>&1; then
+        command -v python
+        return
+    fi
+
+    die "python3 or python is required"
+}
+
+PYTHON_BIN=$(resolve_python)
+REPO_ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+VENDOR_BASE="$REPO_ROOT/vendor/blpapi-sdk"
+CACHE_DIR="$VENDOR_BASE/.cache"
+ENV_FILE="$REPO_ROOT/.env"
+INDEX_URL="https://blpapi.bloomberg.com/repository/releases/python/simple/blpapi/"
+
+MODE="add"
+VERSION=""
+SET_ACTIVE=1
+FORCE=0
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --version)
+            [ $# -ge 2 ] || die "--version requires a value"
+            VERSION=$2
+            shift 2
+            ;;
+        --no-set-active)
+            SET_ACTIVE=0
+            shift
+            ;;
+        --set-active)
+            SET_ACTIVE=1
+            shift
+            ;;
+        --force)
+            FORCE=1
+            shift
+            ;;
+        --remove)
+            MODE="remove"
+            shift
+            ;;
+        --list)
+            MODE="list"
+            shift
+            ;;
+        --clean-cache)
+            MODE="clean-cache"
+            shift
+            ;;
+        --*)
+            die "unknown option: $1"
+            ;;
+        *)
+            if [ -z "$VERSION" ]; then
+                VERSION=$1
+                shift
+            else
+                die "unexpected argument: $1"
+            fi
+            ;;
+    esac
+done
+
+validate_version() {
+    [ -n "$1" ] || die "version is required"
+    if "$PYTHON_BIN" -c "import re,sys; sys.exit(0 if re.fullmatch(r'\\d+\\.\\d+\\.\\d+(?:\\.\\d+)?', sys.argv[1]) else 1)" "$1"; then
+        return
+    else
+        die "invalid version format: $1"
+    fi
+}
+
+download_text() {
+    if command -v curl >/dev/null 2>&1; then
+        curl --fail --silent --show-error --location "$1"
+        return
+    fi
+
+    if command -v wget >/dev/null 2>&1; then
+        wget -qO- "$1"
+        return
+    fi
+
+    die "curl or wget is required"
+}
+
+download_file() {
+    if command -v curl >/dev/null 2>&1; then
+        curl --fail --silent --show-error --location --output "$2" "$1"
+        return
+    fi
+
+    if command -v wget >/dev/null 2>&1; then
+        wget -qO "$2" "$1"
+        return
+    fi
+
+    die "curl or wget is required"
+}
+
+resolve_latest_version() {
+    index_content=$(download_text "$INDEX_URL")
+    INDEX_CONTENT="$index_content" "$PYTHON_BIN" -c "import os,re; versions=sorted({m.group(1) for m in re.finditer(r'blpapi-(\\d+\\.\\d+\\.\\d+(?:\\.\\d+)?)\\.tar\\.gz', os.environ.get('INDEX_CONTENT', ''))}, key=lambda s: tuple(int(part) for part in (s.split('.') + ['0'])[:4])); print(versions[-1] if versions else '')"
+}
+
+get_active_sdk_version() {
+    [ -f "$ENV_FILE" ] || return 0
+    "$PYTHON_BIN" -c "from pathlib import Path; import re,sys; path=Path(sys.argv[1]); match=re.search(r'^\\s*XBBG_DEV_SDK_ROOT\\s*=\\s*.*?/([0-9]+\\.[0-9]+\\.[0-9]+(?:\\.[0-9]+)?)\\s*$', path.read_text(), re.MULTILINE); print(match.group(1) if match else '')" "$ENV_FILE"
+}
+
+set_active_sdk_version() {
+    "$PYTHON_BIN" -c "from pathlib import Path; import sys; env_file=Path(sys.argv[1]); version=sys.argv[2]; env_line=f'XBBG_DEV_SDK_ROOT=vendor/blpapi-sdk/{version}'; content=env_file.read_text() if env_file.exists() else ''; lines=[line for line in content.splitlines() if not line.lstrip().startswith('XBBG_DEV_SDK_ROOT=')]; lines.append(env_line); env_file.write_text('\\n'.join(lines) + '\\n')" "$ENV_FILE" "$VERSION"
+    note "[OK] .env updated: XBBG_DEV_SDK_ROOT=vendor/blpapi-sdk/$VERSION"
+}
+
+clear_active_sdk_version() {
+    [ -f "$ENV_FILE" ] || return 0
+    "$PYTHON_BIN" -c "from pathlib import Path; import sys; env_file=Path(sys.argv[1]); version=sys.argv[2]; target=f'vendor/blpapi-sdk/{version}'; lines=env_file.read_text().splitlines(); kept=[line for line in lines if not (line.lstrip().startswith('XBBG_DEV_SDK_ROOT=') and target in line)]; env_file.write_text('\\n'.join(kept) + '\\n') if kept else env_file.unlink(missing_ok=True)" "$ENV_FILE" "$VERSION"
+}
+
+platform_info() {
+    os_name=$(uname -s 2>/dev/null || printf 'unknown')
+    arch_name=$(uname -m 2>/dev/null || printf 'unknown')
+
+    case "$os_name" in
+        Darwin)
+            case "$arch_name" in
+                arm64|aarch64)
+                    PLATFORM_LABEL="macOS arm64"
+                    ARCHIVE_FILE_NAME="blpapi_cpp_${VERSION}-macos-arm64.tar.gz"
+                    EXTRACTOR="tar.gz"
+                    ;;
+                *)
+                    die "unsupported macOS architecture: $arch_name"
+                    ;;
+            esac
+            ;;
+        Linux)
+            PLATFORM_LABEL="Linux"
+            ARCHIVE_FILE_NAME="blpapi_cpp_${VERSION}-linux.tar.gz"
+            EXTRACTOR="tar.gz"
+            ;;
+        MINGW*|MSYS*|CYGWIN*)
+            PLATFORM_LABEL="Windows"
+            ARCHIVE_FILE_NAME="blpapi_cpp_${VERSION}-windows.zip"
+            EXTRACTOR="zip"
+            ;;
+        *)
+            die "unsupported operating system: $os_name"
+            ;;
+    esac
+
+    ARCHIVE_URL="https://blpapi.bloomberg.com/download/releases/raw/files/$ARCHIVE_FILE_NAME"
+}
+
+extract_archive() {
+    archive_path=$1
+    staging_dir=$2
+
+    case "$EXTRACTOR" in
+        zip)
+            command -v unzip >/dev/null 2>&1 || die "unzip is required for $ARCHIVE_FILE_NAME"
+            unzip -q "$archive_path" -d "$staging_dir"
+            ;;
+        tar.gz)
+            tar -xzf "$archive_path" -C "$staging_dir"
+            ;;
+        *)
+            die "unsupported extractor: $EXTRACTOR"
+            ;;
+    esac
+}
+
+list_versions() {
+    [ -d "$VENDOR_BASE" ] || return 0
+    "$PYTHON_BIN" -c "from pathlib import Path; import re,sys; root=Path(sys.argv[1]); versions=[p.name for p in root.iterdir() if p.is_dir() and re.fullmatch(r'\\d+\\.\\d+\\.\\d+(?:\\.\\d+)?', p.name)]; versions.sort(key=lambda s: tuple(int(part) for part in (s.split('.') + ['0'])[:4])); print('\\n'.join(versions))" "$VENDOR_BASE"
+}
+
+case "$MODE" in
+    clean-cache)
+        if [ ! -d "$CACHE_DIR" ]; then
+            note "No cache directory found. Nothing to clean."
+            exit 0
+        fi
+        set +e
+        found_cache=0
+        for path in "$CACHE_DIR"/*; do
+            if [ -f "$path" ]; then
+                found_cache=1
+                rm -f "$path"
+                note "Removed: ${path##*/}"
+            fi
+        done
+        set -e
+        if [ "$found_cache" -eq 0 ]; then
+            note "Cache is already empty."
+        fi
+        exit 0
+        ;;
+    list)
+        active_version=$(get_active_sdk_version || true)
+        listed=0
+        for version in $(list_versions); do
+            listed=1
+            if [ "$version" = "$active_version" ]; then
+                note "$version (active)"
+            else
+                note "$version"
+            fi
+        done
+        if [ "$listed" -eq 0 ]; then
+            note "No SDK versions installed."
+        fi
+        exit 0
+        ;;
+    remove)
+        validate_version "$VERSION"
+        VERSION_DIR="$VENDOR_BASE/$VERSION"
+        [ -d "$VERSION_DIR" ] || die "version $VERSION is not installed"
+        rm -rf "$VERSION_DIR"
+        note "Removed: $VERSION_DIR"
+        set +e
+        for path in "$CACHE_DIR"/blpapi_cpp_"$VERSION"-*; do
+            [ -e "$path" ] || continue
+            rm -f "$path"
+            note "Removed: ${path##*/}"
+        done
+        set -e
+        if [ "$(get_active_sdk_version || true)" = "$VERSION" ]; then
+            clear_active_sdk_version
+            note "Cleared XBBG_DEV_SDK_ROOT from .env"
+        fi
+        exit 0
+        ;;
+esac
+
+if [ -z "$VERSION" ]; then
+    VERSION=$(resolve_latest_version)
+    [ -n "$VERSION" ] || die "failed to resolve latest SDK version"
+else
+    validate_version "$VERSION"
+fi
+
+platform_info
+
+VERSION_DIR="$VENDOR_BASE/$VERSION"
+ARCHIVE_PATH="$CACHE_DIR/$ARCHIVE_FILE_NAME"
+
+note "Bloomberg C++ SDK"
+note "  Version : $VERSION"
+note "  Platform: $PLATFORM_LABEL"
+note "  Target  : $VERSION_DIR"
+
+if [ -d "$VERSION_DIR" ] && [ "$FORCE" -ne 1 ]; then
+    note "[OK] Version $VERSION is already present."
+    if [ "$SET_ACTIVE" -eq 1 ]; then
+        set_active_sdk_version
+    fi
+    exit 0
+fi
+
+if [ "$FORCE" -eq 1 ] && [ -d "$VERSION_DIR" ]; then
+    rm -rf "$VERSION_DIR"
+fi
+
+mkdir -p "$VENDOR_BASE" "$CACHE_DIR"
+
+if [ -f "$ARCHIVE_PATH" ] && [ "$FORCE" -ne 1 ]; then
+    note "[OK] Using cached download: $ARCHIVE_FILE_NAME"
+else
+    rm -f "$ARCHIVE_PATH"
+    note "[..] Downloading $ARCHIVE_FILE_NAME"
+    download_file "$ARCHIVE_URL" "$ARCHIVE_PATH"
+fi
+
+TMP_EXTRACT=$(mktemp -d "${TMPDIR:-/tmp}/xbbg-sdk.XXXXXX")
+trap 'rm -rf "$TMP_EXTRACT"' EXIT INT TERM HUP
+
+extract_archive "$ARCHIVE_PATH" "$TMP_EXTRACT"
+
+set -- "$TMP_EXTRACT"/*
+if [ "$1" = "$TMP_EXTRACT/*" ]; then
+    mkdir -p "$VERSION_DIR"
+elif [ $# -eq 1 ] && [ -d "$1" ]; then
+    mv "$1" "$VERSION_DIR"
+else
+    mkdir -p "$VERSION_DIR"
+    for entry in "$TMP_EXTRACT"/* "$TMP_EXTRACT"/.[!.]* "$TMP_EXTRACT"/..?*; do
+        [ -e "$entry" ] || continue
+        mv "$entry" "$VERSION_DIR"/
+    done
+fi
+
+if [ "$SET_ACTIVE" -eq 1 ]; then
+    set_active_sdk_version
+fi
+
+note "[OK] Extracted to $VERSION_DIR"
+
+for rel in include lib Linux Darwin bin; do
+    if [ -e "$VERSION_DIR/$rel" ]; then
+        note "  $rel/ : $VERSION_DIR/$rel"
+    fi
+done

--- a/vendor/blpapi-sdk/README.md
+++ b/vendor/blpapi-sdk/README.md
@@ -2,23 +2,33 @@
 
 ## Quick Start
 
-```powershell
+```bash
 # Add the latest SDK version (auto-detected)
-.\scripts\sdktool.ps1
+bash ./scripts/sdktool.sh
 
 # Add a specific version
-.\scripts\sdktool.ps1 -Version 3.25.12.1
+bash ./scripts/sdktool.sh --version <version>
 
 # List installed versions
-.\scripts\sdktool.ps1 -List
+bash ./scripts/sdktool.sh --list
 
 # Remove a version
-.\scripts\sdktool.ps1 -Remove 3.25.12.1
+bash ./scripts/sdktool.sh --remove <version>
 
 # Re-download and re-extract
-.\scripts\sdktool.ps1 -Force
+bash ./scripts/sdktool.sh --version <version> --force
 
-# Free disk space by clearing cached zips
+# Free disk space by clearing cached archives
+bash ./scripts/sdktool.sh --clean-cache
+```
+
+```powershell
+# Windows PowerShell equivalents
+.\scripts\sdktool.ps1
+.\scripts\sdktool.ps1 -Version <version>
+.\scripts\sdktool.ps1 -List
+.\scripts\sdktool.ps1 -Remove <version>
+.\scripts\sdktool.ps1 -Version <version> -Force
 .\scripts\sdktool.ps1 -CleanCache
 ```
 
@@ -28,21 +38,24 @@
 vendor/
 └── blpapi-sdk/
     ├── README.md            # This file (tracked in git)
-    ├── .cache/              # Downloaded zips (reusable)
-    ├── 3.25.12.1/           # Extracted SDK
+    ├── .cache/              # Downloaded archives (reusable)
+    ├── 3.26.2.1/            # Extracted SDK
     │   ├── include/         # C/C++ headers (blpapi_*.h)
-    │   ├── lib/             # Import libraries (.lib / .dll)
-    │   ├── bin/             # Example executables + runtime DLLs
+    │   ├── Darwin/          # macOS runtime libraries
+    │   ├── Linux/           # Linux runtime libraries
+    │   ├── lib/             # Windows import/runtime libraries
+    │   ├── bin/             # Windows runtime DLLs + tools
     │   └── ...
-    └── 3.24.0.1/            # Another version (optional)
+    └── <another-version>/   # Another version (optional)
 ```
 
 The script writes `XBBG_DEV_SDK_ROOT=vendor/blpapi-sdk/<version>` to `.env` at the repo root.
-The build system (`crates/blpapi-sys/build.rs`) reads this env var to locate `include/` and `lib/`.
+The build system (`crates/blpapi-sys/build.rs`) can use the active `.env` version or scan
+installed SDK versions under `vendor/blpapi-sdk/`.
 
 ## Notes
 
 - Everything under `vendor/blpapi-sdk/` except this README is git-ignored.
 - The official Python `blpapi` wheels already bundle the C++ runtime for supported platforms.
   Use the SDK here only for building from source or running C++ tooling.
-- Download source: `https://blpapi.bloomberg.com/download/releases/raw/files/blpapi_cpp_<VERSION>-windows.zip`
+- The helper scripts auto-detect the host OS and choose the Bloomberg archive format for that platform.


### PR DESCRIPTION
## Summary
- add `xbbg.testing` helpers for Bloomberg-style mock events, mock responses, and `mock_engine` interception so xbbg request flows can be unit tested without a authorized environment
- make Bloomberg SDK setup version-agnostic locally, add cross-platform repo SDK tools, and centralize explicit SDK setup in CI workflows
- refresh SDK setup docs and add focused `xbbg.testing` coverage, including a generic `request()` mock path test