### PR TITLE
feat: SOCKS5 proxy support for Bloomberg connections

### DIFF
--- a/bindings/pyo3-xbbg/src/lib.rs
+++ b/bindings/pyo3-xbbg/src/lib.rs
@@ -411,6 +411,12 @@ pub struct PyEngineConfig {
     pub health_check_interval_ms: u64,
     #[pyo3(get, set)]
     pub sdk_log_level: String,
+    /// SOCKS5 proxy hostname for Bloomberg connections.
+    #[pyo3(get, set)]
+    pub socks5_host: Option<String>,
+    /// SOCKS5 proxy port (required when socks5_host is set).
+    #[pyo3(get, set)]
+    pub socks5_port: Option<u16>,
 }
 
 #[gen_stub_pymethods]
@@ -459,6 +465,8 @@ impl PyEngineConfig {
             retry_max_delay_ms: 30_000,
             health_check_interval_ms: 30_000,
             sdk_log_level: "off".to_string(),
+            socks5_host: None,
+            socks5_port: None,
         };
 
         if let Some(kw) = kwargs {
@@ -566,6 +574,12 @@ impl PyEngineConfig {
             }
             if let Some(v) = kw.get_item("sdk_log_level")? {
                 config.sdk_log_level = v.extract()?;
+            }
+            if let Some(v) = kw.get_item("socks5_host")? {
+                config.socks5_host = v.extract()?;
+            }
+            if let Some(v) = kw.get_item("socks5_port")? {
+                config.socks5_port = v.extract()?;
             }
         }
 
@@ -708,6 +722,8 @@ impl TryFrom<&PyEngineConfig> for EngineConfig {
                 .sdk_log_level
                 .parse()
                 .map_err(|e: String| pyo3::exceptions::PyValueError::new_err(e))?,
+            socks5_host: py_config.socks5_host.clone(),
+            socks5_port: py_config.socks5_port,
         })
     }
 }
@@ -2052,7 +2068,10 @@ fn dict_to_request_params(dict: &Bound<'_, PyDict>) -> PyResult<RequestParams> {
         .map(|v| v.extract())
         .transpose()?;
 
-    let request_id: Option<String> = dict.get_item("request_id")?.map(|v| v.extract()).transpose()?;
+    let request_id: Option<String> = dict
+        .get_item("request_id")?
+        .map(|v| v.extract())
+        .transpose()?;
 
     // Optional fields
     let securities: Option<Vec<String>> = dict

--- a/crates/xbbg-async/src/engine/mod.rs
+++ b/crates/xbbg-async/src/engine/mod.rs
@@ -63,8 +63,23 @@ fn configure_session_options(
     } else {
         &config.servers
     };
+    // Build optional SOCKS5 proxy config
+    let socks5 = match (config.socks5_host.as_deref(), config.socks5_port) {
+        (Some(host), Some(port)) => Some(xbbg_core::socks5::Socks5Config::new(host, port)?),
+        (Some(_), None) => {
+            return Err(BlpError::InvalidArgument {
+                detail: "socks5_host set without socks5_port".into(),
+            });
+        }
+        _ => None,
+    };
+
     for (index, (host, port)) in servers.iter().enumerate() {
-        options.set_server_address(host, *port, index)?;
+        if let Some(ref proxy) = socks5 {
+            options.set_server_address_with_proxy(host, *port, proxy, index)?;
+        } else {
+            options.set_server_address(host, *port, index)?;
+        }
     }
     options.set_num_start_attempts(config.num_start_attempts)?;
     options.set_auto_restart_on_disconnection(config.auto_restart_on_disconnection);
@@ -1260,6 +1275,10 @@ pub struct EngineConfig {
     /// Bloomberg SDK internal log level. Bridges SDK logs into xbbg tracing.
     /// Must be set before first session starts. Default: Off.
     pub sdk_log_level: crate::sdk_logging::SdkLogLevel,
+    /// SOCKS5 proxy hostname. When set, all server connections route through this proxy.
+    pub socks5_host: Option<String>,
+    /// SOCKS5 proxy port (required when socks5_host is set).
+    pub socks5_port: Option<u16>,
 }
 impl Default for EngineConfig {
     fn default() -> Self {
@@ -1294,6 +1313,8 @@ impl Default for EngineConfig {
             retry_policy: RetryPolicy::default(),
             health_check_interval_ms: 30_000,
             sdk_log_level: crate::sdk_logging::SdkLogLevel::Off,
+            socks5_host: None,
+            socks5_port: None,
         }
     }
 }

--- a/crates/xbbg-core/src/ffi.rs
+++ b/crates/xbbg-core/src/ffi.rs
@@ -156,6 +156,15 @@ pub use xbbg_sys::{
     blpapi_TlsOptions_setTlsHandshakeTimeoutMs,
 };
 
+// --- Socks5Config type ---
+pub use xbbg_sys::blpapi_Socks5Config_t;
+
+// --- Socks5Config functions ---
+pub use xbbg_sys::{blpapi_Socks5Config_create, blpapi_Socks5Config_destroy};
+
+// --- SessionOptions proxy function ---
+pub use xbbg_sys::blpapi_SessionOptions_setServerAddressWithProxy;
+
 // --- Identity functions ---
 pub use xbbg_sys::{
     blpapi_Identity_getSeatType, blpapi_Identity_hasEntitlements, blpapi_Identity_isAuthorized,

--- a/crates/xbbg-core/src/lib.rs
+++ b/crates/xbbg-core/src/lib.rs
@@ -33,6 +33,7 @@ pub mod request;
 pub mod schema;
 pub mod service;
 pub mod session;
+pub mod socks5;
 pub mod subscription;
 pub mod tls;
 pub mod zfp;
@@ -53,6 +54,7 @@ pub use name::{clear_name_cache, name_cache_size, Name};
 pub use request::Request;
 pub use service::Service;
 pub use session::{Session, SessionOptions};
+pub use socks5::Socks5Config;
 pub use subscription::SubscriptionList;
 pub use value::{OwnedValue, Value};
 

--- a/crates/xbbg-core/src/options.rs
+++ b/crates/xbbg-core/src/options.rs
@@ -57,6 +57,35 @@ impl SessionOptions {
         Ok(self)
     }
 
+    pub fn set_server_address_with_proxy(
+        &mut self,
+        host: &str,
+        port: u16,
+        socks5: &crate::socks5::Socks5Config,
+        index: usize,
+    ) -> Result<&mut Self> {
+        let cs = CString::new(host).map_err(|e| BlpError::InvalidArgument {
+            detail: format!("invalid host: {e}"),
+        })?;
+        let rc = unsafe {
+            ffi::blpapi_SessionOptions_setServerAddressWithProxy(
+                self.ptr,
+                cs.as_ptr(),
+                port,
+                socks5.as_ptr(),
+                index,
+            )
+        };
+        if rc != 0 {
+            return Err(BlpError::InvalidArgument {
+                detail: format!(
+                    "setServerAddressWithProxy failed: host={host} port={port} index={index} rc={rc}"
+                ),
+            });
+        }
+        Ok(self)
+    }
+
     pub fn set_session_identity_options(
         &mut self,
         auth_options: &AuthOptions,

--- a/crates/xbbg-core/src/socks5.rs
+++ b/crates/xbbg-core/src/socks5.rs
@@ -1,0 +1,41 @@
+use std::ffi::CString;
+
+use crate::errors::{BlpError, Result};
+use crate::ffi;
+
+/// Safe wrapper around `blpapi_Socks5Config_t`.
+pub struct Socks5Config {
+    ptr: *mut ffi::blpapi_Socks5Config_t,
+}
+
+unsafe impl Send for Socks5Config {}
+unsafe impl Sync for Socks5Config {}
+
+impl Socks5Config {
+    pub fn new(hostname: &str, port: u16) -> Result<Self> {
+        let cs = CString::new(hostname).map_err(|e| BlpError::InvalidArgument {
+            detail: format!("invalid socks5 hostname: {e}"),
+        })?;
+        let ptr =
+            unsafe { ffi::blpapi_Socks5Config_create(cs.as_ptr(), cs.as_bytes().len(), port) };
+        if ptr.is_null() {
+            return Err(BlpError::Internal {
+                detail: "blpapi_Socks5Config_create returned null".into(),
+            });
+        }
+        Ok(Self { ptr })
+    }
+
+    pub(crate) fn as_ptr(&self) -> *const ffi::blpapi_Socks5Config_t {
+        self.ptr
+    }
+}
+
+impl Drop for Socks5Config {
+    fn drop(&mut self) {
+        if !self.ptr.is_null() {
+            unsafe { ffi::blpapi_Socks5Config_destroy(self.ptr) };
+            self.ptr = std::ptr::null_mut();
+        }
+    }
+}

--- a/py-xbbg/src/xbbg/_core/__init__.pyi
+++ b/py-xbbg/src/xbbg/_core/__init__.pyi
@@ -548,6 +548,26 @@ class PyEngineConfig:
     def sdk_log_level(self) -> builtins.str: ...
     @sdk_log_level.setter
     def sdk_log_level(self, value: builtins.str) -> None: ...
+    @property
+    def socks5_host(self) -> typing.Optional[builtins.str]:
+        r"""
+        SOCKS5 proxy hostname for Bloomberg connections.
+        """
+    @socks5_host.setter
+    def socks5_host(self, value: typing.Optional[builtins.str]) -> None:
+        r"""
+        SOCKS5 proxy hostname for Bloomberg connections.
+        """
+    @property
+    def socks5_port(self) -> typing.Optional[builtins.int]:
+        r"""
+        SOCKS5 proxy port (required when socks5_host is set).
+        """
+    @socks5_port.setter
+    def socks5_port(self, value: typing.Optional[builtins.int]) -> None:
+        r"""
+        SOCKS5 proxy port (required when socks5_host is set).
+        """
     def __new__(cls, **kwargs: typing.Any) -> PyEngineConfig:
         r"""
         Create a new configuration with defaults.


### PR DESCRIPTION
## Summary

Adds `socks5_host` and `socks5_port` kwargs to `configure()` and `Engine()` for routing Bloomberg connections through a SOCKS5 proxy.

- Safe `Socks5Config` wrapper in `xbbg-core` (create/destroy lifecycle, Send+Sync)
- `set_server_address_with_proxy()` on `SessionOptions`
- `socks5_host`/`socks5_port` fields threaded through `EngineConfig` → `PyEngineConfig`
- Proxy applied to all servers in the server list; error if host set without port

```python
blp.configure(host="<authorized-host>", port=8294,
              socks5_host="<proxy-host>", socks5_port=1080)
```

Closes #180

## Test plan

- [x] `cargo check` passes for xbbg-core, xbbg-async, pyo3-xbbg
- [x] `cargo fmt --all` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)