### PR TITLE
fix(engine): preserve native value types in bdp/bdh long format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 - **`xbbg-mcp` local MCP server**: Added a stdio Bloomberg MCP application under `apps/xbbg-mcp` with tool surfaces for `bdp`, `bdh`, `bds`, `bdib`, `bql`, `bsrch`, `bflds`, and generic request execution. Responses are bounded structured JSON with Arrow schema metadata for coding agents.
 - **GitHub-release MCP distribution path**: Added release packaging for `xbbg-mcp`, a Unix launcher wrapper (`scripts/xbbg-mcp`), and a convenience installer (`scripts/install-xbbg-mcp.sh`) so Claude Code and OpenCode users can install a local MCP binary without cloning or compiling the repo first.
 
+### Fixed
+
+- **Incorrect value types in `bdp`/`bdh` long format (issue #280)**: The default long format (`LongMode::String`) was converting all Bloomberg values to strings, ignoring resolved `field_types`. Now the Rust engine computes a common Arrow type from the field type hints at construction time — when all fields are numeric, the `value` column is `Float64` instead of `Utf8`. Mixed-type queries (e.g., numeric + string fields) gracefully fall back to string. The fix is zero-copy: `Value` is moved into the Arrow builder instead of being stringified and re-parsed.
+- **Incorrect timestamp in `parse_rfc3339_utc` test**: Fixed hardcoded expected value from `1717242600` to `1717252200` (correct UTC epoch for `2024-06-01T14:30:00+00:00`).
+
 
 ## [1.0.0] - 2026-03-31
 

--- a/crates/xbbg-async/src/engine/intraday_timezone.rs
+++ b/crates/xbbg-async/src/engine/intraday_timezone.rs
@@ -306,7 +306,7 @@ mod tests {
     fn parse_rfc3339_utc() {
         let u = parse_user_datetime("2024-06-01T14:30:00+00:00").unwrap();
         match u {
-            UserDateTime::Utc(dt) => assert_eq!(dt.timestamp(), 1717242600),
+            UserDateTime::Utc(dt) => assert_eq!(dt.timestamp(), 1717252200),
             UserDateTime::Naive(_) => panic!("expected utc"),
         }
     }

--- a/crates/xbbg-async/src/engine/state/histdata.rs
+++ b/crates/xbbg-async/src/engine/state/histdata.rs
@@ -72,6 +72,13 @@ impl HistDataState {
             columns.set_type_hint(name, *arrow_type);
         }
 
+        // Set type hint for the "value" column based on common field type.
+        if long_mode == LongMode::String {
+            use super::value_utils::common_value_type;
+            let common_type = common_value_type(&arrow_types);
+            columns.set_type_hint("value", common_type);
+        }
+
         Self {
             field_names: fields,
             field_types: arrow_types,
@@ -212,7 +219,7 @@ impl HistDataState {
                 .as_ref()
                 .map(|v| dtype_from_hints(field_types, field_name, v));
 
-            append_long_value_row(columns, long_mode, field_name, &value, dtype, |columns| {
+            append_long_value_row(columns, long_mode, field_name, value, dtype, |columns| {
                 columns.append_str("ticker", ticker);
                 if let Some(date_value) = date_value {
                     columns.append("date", date_value.clone());

--- a/crates/xbbg-async/src/engine/state/refdata.rs
+++ b/crates/xbbg-async/src/engine/state/refdata.rs
@@ -90,6 +90,15 @@ impl RefDataState {
             columns.set_type_hint(name, *arrow_type);
         }
 
+        // Set type hint for the "value" column based on common field type.
+        // If all fields are numeric, the value column will be Float64 instead
+        // of Utf8, preserving native types from the Bloomberg response.
+        if long_mode == LongMode::String {
+            use super::value_utils::common_value_type;
+            let common_type = common_value_type(&arrow_types);
+            columns.set_type_hint("value", common_type);
+        }
+
         Self {
             field_names: fields,
             field_types: arrow_types,
@@ -306,7 +315,7 @@ impl RefDataState {
             &mut self.columns,
             self.long_mode,
             "__SECURITY_ERROR__",
-            &value,
+            value,
             Some("string"),
             |columns| columns.append_str("ticker", ticker),
         );
@@ -328,7 +337,7 @@ impl RefDataState {
                 .as_ref()
                 .map(|v| dtype_from_hints(field_types, field_name, v));
 
-            append_long_value_row(columns, long_mode, field_name, &value, dtype, |columns| {
+            append_long_value_row(columns, long_mode, field_name, value, dtype, |columns| {
                 columns.append_str("ticker", ticker)
             });
         }

--- a/crates/xbbg-async/src/engine/state/value_utils.rs
+++ b/crates/xbbg-async/src/engine/state/value_utils.rs
@@ -1,14 +1,44 @@
 use std::borrow::Cow;
+use std::collections::HashMap;
 
 use super::refdata::LongMode;
-use super::typed_builder::ColumnSet;
+use super::typed_builder::{ArrowType, ColumnSet};
 use xbbg_core::Value;
+
+/// Compute the common Arrow type for the "value" column from field type hints.
+///
+/// If all fields resolve to the same numeric type family, returns that type
+/// (promoting mixed int/float to Float64). If any field is non-numeric or no
+/// hints are provided, falls back to String.
+pub(crate) fn common_value_type(field_types: &HashMap<String, ArrowType>) -> ArrowType {
+    if field_types.is_empty() {
+        return ArrowType::String;
+    }
+
+    let mut has_float = false;
+    let mut has_int = false;
+
+    for arrow_type in field_types.values() {
+        match arrow_type {
+            ArrowType::Float64 => has_float = true,
+            ArrowType::Int64 | ArrowType::Int32 => has_int = true,
+            // Any non-numeric type → fall back to string
+            _ => return ArrowType::String,
+        }
+    }
+
+    if has_float || has_int {
+        ArrowType::Float64
+    } else {
+        ArrowType::String
+    }
+}
 
 pub(crate) fn append_long_value_row<F>(
     columns: &mut ColumnSet,
     long_mode: LongMode,
     field_name: &str,
-    value: &Option<Value<'_>>,
+    value: Option<Value<'_>>,
     dtype: Option<&str>,
     prefix: F,
 ) where
@@ -19,15 +49,14 @@ pub(crate) fn append_long_value_row<F>(
 
     match long_mode {
         LongMode::String => {
-            if let Some(value) = value.as_ref() {
-                let value_str = value_to_string(value);
-                columns.append_str("value", value_str.as_ref());
+            if let Some(value) = value {
+                columns.append("value", value);
             } else {
                 columns.append_null("value");
             }
         }
         LongMode::WithMetadata => {
-            if let Some(value) = value.as_ref() {
+            if let Some(ref value) = value {
                 let value_str = value_to_string(value);
                 columns.append_str("value", value_str.as_ref());
                 columns.append_str("dtype", dtype.unwrap_or("null"));


### PR DESCRIPTION
## Summary

- Fixes #280 — `blp.bdp` and `blp.bdh` were returning string values instead of proper numeric types (e.g., `float64`) in the default long format
- The Rust engine now computes a common Arrow type from resolved `field_types` at construction time. When all fields are numeric, the `value` column is `Float64` instead of `Utf8`. Mixed-type queries (numeric + string fields) gracefully fall back to string
- Zero-copy: `Value` is moved into the Arrow builder instead of being stringified via `value_to_string`
- Also fixes an incorrect expected timestamp in the `parse_rfc3339_utc` test

## Test plan

- [x] `cargo build -p xbbg-async` compiles cleanly
- [x] All 96 unit tests in `xbbg-async` pass (including the fixed timestamp test)
- [ ] Verify with Bloomberg terminal: `blp.bdp('SPX Index', 'PX_LAST')` returns `float64` value column
- [ ] Verify mixed-type query (e.g., `PX_LAST` + `SECURITY_NAME`) falls back to string column
- [ ] Verify `blp.bdh` returns `float64` value column for price fields
- [ ] Verify explicit `field_types={'PX_LAST': 'float64'}` is respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)