### PR TITLE
fix(async): route semi_long format to Wide output for bdp/bdh

### DIFF
--- a/crates/xbbg-async/src/engine/worker.rs
+++ b/crates/xbbg-async/src/engine/worker.rs
@@ -633,18 +633,21 @@ impl RequestWorker {
 
         let state = match params.extractor {
             ExtractorType::RefData => {
-                let long_mode = params
+                let (output_format, long_mode) = params
                     .format
                     .as_deref()
                     .map(|s| match s {
-                        "long_typed" | "typed" => LongMode::Typed,
-                        "long_metadata" | "metadata" | "with_metadata" => LongMode::WithMetadata,
-                        _ => LongMode::String,
+                        "semi_long" | "wide" => (OutputFormat::Wide, LongMode::String),
+                        "long_typed" | "typed" => (OutputFormat::Long, LongMode::Typed),
+                        "long_metadata" | "metadata" | "with_metadata" => {
+                            (OutputFormat::Long, LongMode::WithMetadata)
+                        }
+                        _ => (OutputFormat::Long, LongMode::String),
                     })
-                    .unwrap_or(LongMode::String);
+                    .unwrap_or((OutputFormat::Long, LongMode::String));
                 UnifiedRequestState::RefData(RefDataState::with_format(
                     fields,
-                    OutputFormat::Long,
+                    output_format,
                     long_mode,
                     field_types,
                     params.include_security_errors,
@@ -657,7 +660,7 @@ impl RequestWorker {
                     .format
                     .as_deref()
                     .map(|s| match s {
-                        "wide" => (OutputFormat::Wide, LongMode::String),
+                        "semi_long" | "wide" => (OutputFormat::Wide, LongMode::String),
                         "long_typed" | "typed" => (OutputFormat::Long, LongMode::Typed),
                         "long_metadata" | "metadata" | "with_metadata" => {
                             (OutputFormat::Long, LongMode::WithMetadata)

--- a/py-xbbg/tests/live/test_api.py
+++ b/py-xbbg/tests/live/test_api.py
@@ -297,6 +297,118 @@ class TestAbdh:
 
 
 # =============================================================================
+# Output Format Tests - regression coverage for bdp/bdh format= variants
+# =============================================================================
+
+
+class TestOutputFormats:
+    """Shape assertions for every Format variant on bdp and bdh.
+
+    Regression for #296 — semi_long silently returned long shape because
+    the worker had no "semi_long" arm for RefData or HistData.
+    """
+
+    def test_bdp_long(self):
+        from xbbg import bdp
+
+        fields = [CONFIG.price_field, CONFIG.name_field]
+        df = bdp(CONFIG.equity_multi, fields, format="long")
+
+        assert list(df.columns) == ["ticker", "field", "value"]
+        assert len(df) == len(CONFIG.equity_multi) * len(fields)
+
+    def test_bdp_semi_long(self):
+        from xbbg import bdp
+
+        fields = [CONFIG.price_field, CONFIG.name_field]
+        df = bdp(CONFIG.equity_multi, fields, format="semi_long")
+
+        assert list(df.columns) == ["ticker", *fields]
+        assert len(df) == len(CONFIG.equity_multi)
+
+    def test_bdp_long_typed(self):
+        from xbbg import bdp
+
+        df = bdp(CONFIG.equity_multi, [CONFIG.price_field], format="long_typed")
+
+        assert list(df.columns) == [
+            "ticker",
+            "field",
+            "value_f64",
+            "value_i64",
+            "value_str",
+            "value_bool",
+            "value_date",
+            "value_ts",
+        ]
+        assert len(df) == len(CONFIG.equity_multi)
+
+    def test_bdp_long_metadata(self):
+        from xbbg import bdp
+
+        df = bdp(CONFIG.equity_multi, [CONFIG.price_field], format="long_metadata")
+
+        assert list(df.columns) == ["ticker", "field", "value", "dtype"]
+        pdf = df.to_pandas()
+        assert set(pdf["dtype"].unique()) == {"float64"}
+
+    def test_bdh_long(self):
+        from xbbg import bdh
+
+        start, end = get_date_range(5)
+        df = bdh(CONFIG.equity_single, [CONFIG.price_field], start_date=start, end_date=end, format="long")
+
+        assert list(df.columns) == ["ticker", "date", "field", "value"]
+
+    def test_bdh_semi_long(self):
+        from xbbg import bdh
+
+        start, end = get_date_range(5)
+        fields = [CONFIG.price_field, CONFIG.volume_field]
+        df = bdh(CONFIG.equity_single, fields, start_date=start, end_date=end, format="semi_long")
+
+        assert list(df.columns) == ["ticker", "date", *fields]
+
+    def test_bdh_long_typed(self):
+        from xbbg import bdh
+
+        start, end = get_date_range(5)
+        df = bdh(
+            CONFIG.equity_single,
+            [CONFIG.price_field],
+            start_date=start,
+            end_date=end,
+            format="long_typed",
+        )
+
+        assert list(df.columns) == [
+            "ticker",
+            "date",
+            "field",
+            "value_f64",
+            "value_i64",
+            "value_str",
+            "value_bool",
+            "value_date",
+            "value_ts",
+        ]
+
+    def test_bdh_long_metadata(self):
+        from xbbg import bdh
+
+        start, end = get_date_range(5)
+        df = bdh(
+            CONFIG.equity_single,
+            [CONFIG.price_field],
+            start_date=start,
+            end_date=end,
+            format="long_metadata",
+        )
+
+        assert list(df.columns) == ["ticker", "date", "field", "value", "dtype"]
+
+
+# =============================================================================
 # BDS Tests - Bulk Data
 # =============================================================================
 


### PR DESCRIPTION
## Summary
Fixes #296.

`bdp(..., format='semi_long')` and `bdh(..., format='semi_long')` were silently returning long-shape output (`ticker, field, value`) instead of the documented wide-per-ticker shape. Root cause: the worker's format string match had no `"semi_long"` arm — RefData hardcoded `OutputFormat::Long` and only varied `LongMode`, and HistData only recognised `"wide"`.

Map `"semi_long" | "wide"` → `OutputFormat::Wide` in both arms (`crates/xbbg-async/src/engine/worker.rs`). 10-line change.

## Live verification (BBCOMM)
Before:
- `bdp semi_long` → `[ticker, field, value]`, 6×3
- `bdh semi_long` → `[ticker, date, field, value]`, 12×4

After:
- `bdp semi_long` → `[ticker, PX_LAST, PX_OPEN, ID_BB_GLOBAL]`, 2×4, typed columns (`f64` / `str`)
- `bdh semi_long` → `[ticker, date, PX_LAST, PX_OPEN]`, 6×4, `f64`

Also re-verified `long`, `long_typed`, `long_metadata` on both endpoints — unchanged.

## Test plan
- [x] Live `bdp` against real BBCOMM for all four `Format` variants
- [x] Live `bdh` against real BBCOMM for all four `Format` variants
- [ ] Add a pytest-based shape assertion for `semi_long` on both endpoints (follow-up — current suite has zero `semi_long` coverage, which is why this shipped broken)
- [ ] `cargo test -p xbbg-async`