### PR TITLE
style(napi): apply rustfmt to recipe_cdx_ticker signature

### DIFF
--- a/bindings/napi-xbbg/src/lib.rs
+++ b/bindings/napi-xbbg/src/lib.rs
@@ -1205,11 +1205,7 @@ impl JsEngine {
     }
 
     #[napi]
-    pub async fn recipe_cdx_ticker(
-        &self,
-        gen_ticker: String,
-        dt: String,
-    ) -> napi::Result<Buffer> {
+    pub async fn recipe_cdx_ticker(&self, gen_ticker: String, dt: String) -> napi::Result<Buffer> {
         let engine = self.engine.clone();
         let batch = xbbg_recipes::futures::recipe_cdx_ticker(&engine, gen_ticker, dt)
             .await


### PR DESCRIPTION
## Summary
- `cargo fmt --all --check` flags `bindings/napi-xbbg/src/lib.rs:1208` — `recipe_cdx_ticker`'s signature was split across 5 lines but fits on one under rustfmt's default width.
- Pre-existing violation introduced with the napi recipe bindings (commit 91a232e), not a style preference change.

## Test plan
- [x] `cargo fmt --all --check` now clean