### PR TITLE
fix(core): accept whole-number Float64 in Int builders for semi_long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 
 ## [Unreleased]
 
+### Fixed
+
+- **`bdh` / `bdp` with `format='semi_long'` dropped Int64-typed fields (#303)**: Bloomberg sends integer-typed fields (`PX_VOLUME`, `OPEN_INT`, etc.) as Float64 on the wire in HistoricalDataResponse even though FieldInfo declares them `Int64`/`Long`. `crates/xbbg-core/src/value.rs::Value::as_i64` (and its `OwnedValue` twin) and the inline `TypedBuilder::Int32::append_value` match in `crates/xbbg-async/src/engine/state/typed_builder.rs` had no Float64 arm, so the wide-path Int builder null-filled those columns. Consequence: `blp.bdh("ESH20 Index", flds=[..., "PX_VOLUME", "OPEN_INT"], format='semi_long')` returned NaN for every volume / open-interest row. `long` / `long_typed` / `long_metadata` were unaffected because their builders route via Float64 or stringify. Fixed by accepting `Float64` when it's finite, has `fract()==0.0`, and fits the target integer range. `TestOutputFormats::test_bdh_semi_long_integer_fields_issue_303` locks this in live, plus existing `bdp`/`bdh` `semi_long` tests now assert `notna().all()` per column instead of just column names.
+
 ## [1.1.1] - 2026-04-20
 
 ### Added

--- a/crates/xbbg-async/src/engine/state/typed_builder.rs
+++ b/crates/xbbg-async/src/engine/state/typed_builder.rs
@@ -151,6 +151,14 @@ impl TypedBuilder {
                     Value::Int64(i) => Some(i as i32),
                     Value::Byte(i) => Some(i as i32),
                     Value::Bool(b) => Some(if b { 1 } else { 0 }),
+                    Value::Float64(f)
+                        if f.is_finite()
+                            && f.fract() == 0.0
+                            && f >= i32::MIN as f64
+                            && f <= i32::MAX as f64 =>
+                    {
+                        Some(f as i32)
+                    }
                     _ => None,
                 }) {
                     b.append_value(v);

--- a/crates/xbbg-core/src/value.rs
+++ b/crates/xbbg-core/src/value.rs
@@ -89,6 +89,17 @@ impl<'a> Value<'a> {
             Self::Date32(v) => Some(*v as i64),
             Self::TimestampMicros(v) => Some(*v),
             Self::Time64Micros(v) => Some(*v),
+            // Bloomberg often sends integer-typed fields (e.g. PX_VOLUME, OPEN_INT)
+            // as Float64 in HistoricalDataResponse. Accept only whole numbers within
+            // i64 range; anything with a fractional part stays None.
+            Self::Float64(v)
+                if v.is_finite()
+                    && v.fract() == 0.0
+                    && *v >= i64::MIN as f64
+                    && *v <= i64::MAX as f64 =>
+            {
+                Some(*v as i64)
+            }
             _ => None,
         }
     }
@@ -175,6 +186,14 @@ impl OwnedValue {
             Self::Date32(v) => Some(*v as i64),
             Self::TimestampMicros(v) => Some(*v),
             Self::Time64Micros(v) => Some(*v),
+            Self::Float64(v)
+                if v.is_finite()
+                    && v.fract() == 0.0
+                    && *v >= i64::MIN as f64
+                    && *v <= i64::MAX as f64 =>
+            {
+                Some(*v as i64)
+            }
             _ => None,
         }
     }

--- a/py-xbbg/tests/live/test_api.py
+++ b/py-xbbg/tests/live/test_api.py
@@ -325,6 +325,9 @@ class TestOutputFormats:
 
         assert list(df.columns) == ["ticker", *fields]
         assert len(df) == len(CONFIG.equity_multi)
+        pdf = df.to_pandas()
+        for field in fields:
+            assert pdf[field].notna().all(), f"semi_long {field} column contains NaN"
 
     def test_bdp_long_typed(self):
         from xbbg import bdp
@@ -368,6 +371,31 @@ class TestOutputFormats:
         df = bdh(CONFIG.equity_single, fields, start_date=start, end_date=end, format="semi_long")
 
         assert list(df.columns) == ["ticker", "date", *fields]
+        pdf = df.to_pandas()
+        for field in fields:
+            assert pdf[field].notna().all(), f"semi_long {field} column contains NaN"
+
+    def test_bdh_semi_long_integer_fields_issue_303(self):
+        """Regression for #303: bdh semi_long dropped Int64-typed fields.
+
+        Bloomberg sends PX_VOLUME / OPEN_INT as Float64 in HistoricalDataResponse
+        even though FieldInfo types them as Int64. Before the fix, the typed
+        Int64 builder rejected Float64 values and null-filled the column.
+        """
+        from xbbg import bdh
+
+        # Window well before today so OPEN_INT is fully published for every row.
+        end = datetime.now() - timedelta(days=14)
+        start = end - timedelta(days=5)
+        start, end = start.strftime("%Y-%m-%d"), end.strftime("%Y-%m-%d")
+        fields = ["PX_LAST", "PX_VOLUME", "OPEN_INT"]
+        df = bdh(CONFIG.futures_generic, fields, start_date=start, end_date=end, format="semi_long")
+
+        assert list(df.columns) == ["ticker", "date", *fields]
+        assert len(df) > 0, "expected at least one row for the historical window"
+        pdf = df.to_pandas()
+        for field in fields:
+            assert pdf[field].notna().all(), f"#303 regression — {field} column contains NaN"
 
     def test_bdh_long_typed(self):
         from xbbg import bdh


### PR DESCRIPTION
## Summary
Fixes #303.

Bloomberg sends integer-typed fields (`PX_VOLUME`, `OPEN_INT`, …) as **Float64** on the wire in `HistoricalDataResponse` even though `FieldInfo` declares them `Int64`/`Long`. The wide-path Int builders — `TypedBuilder::Int64` (via `Value::as_i64`) and the inline `TypedBuilder::Int32` match in `crates/xbbg-async/src/engine/state/typed_builder.rs` — had no `Float64` arm, so `format='semi_long'` null-filled every Int-typed column.

Fix: coerce `Value::Float64` to `i64`/`i32` when the value is finite, `fract()==0.0`, and fits the target range. Applied symmetrically to `Value::as_i64` and `OwnedValue::as_i64` in `crates/xbbg-core/src/value.rs` plus the inline `Int32` match.

Long variants (`long`, `long_typed`, `long_metadata`) were unaffected because their builders route via Float64 or stringify.

## Why my #299 tests missed this
`TestOutputFormats` only asserted `list(df.columns) == [...]`; it didn't check values. `bdh(..., format='semi_long')` returned the expected columns — just all NaN for integer fields. Tightened: `notna().all()` per column, plus a dedicated regression test on `PX_VOLUME` / `OPEN_INT` against a historical window.

## Live verification (BBCOMM)
Before (from user's repro):

```
date        PX_SETTLE  PX_LAST  PX_VOLUME  OPEN_INT
2020-01-02  3259.0     3259.0   null       null
2020-01-03  3235.5     3235.5   null       null
...
```

After:

```
date        PX_SETTLE  PX_LAST  PX_VOLUME  OPEN_INT
2020-01-02  3259.0     3259.0   1416241    2740796
2020-01-03  3235.5     3235.5   1755057    2699160
2020-01-06  3243.5     3243.5   1502748    2688734
2020-01-07  3235.25    3235.25  1293494    2689622
...
```

## Test plan
- [x] 9/9 `TestOutputFormats` live tests pass including new `test_bdh_semi_long_integer_fields_issue_303`
- [x] `ruff check` / `ruff format --check` clean
- [x] `cargo fmt --all --check` clean
- [x] `pixi run --environment default test` passes (full Python + Rust suite)