### PR TITLE
Support notebook sync wrappers

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -1141,7 +1141,7 @@ jobs:
         run: cargo build -p pyo3-xbbg --bin stub_gen --no-default-features --features live
 
       - name: Regenerate stubs
-        run: CARGO_MANIFEST_DIR=${{ github.workspace }}/bindings/pyo3-xbbg ./target/debug/stub_gen
+        run: CARGO_MANIFEST_DIR="$GITHUB_WORKSPACE/bindings/pyo3-xbbg" ./target/debug/stub_gen
 
       - name: Commit stubs if changed
         run: |

--- a/README.md
+++ b/README.md
@@ -785,29 +785,32 @@ multiple = asyncio.run(get_multiple())
 
 #### In Jupyter notebooks
 
-Jupyter already runs an event loop, so `asyncio.run()` will raise `RuntimeError: asyncio.run() cannot be called from a running event loop`. Use `await` directly in notebook cells instead:
+Jupyter and VS Code Interactive already run an event loop. For one-shot request/response calls, you can keep using the familiar sync API:
 
 ```python
 from xbbg import blp
 
-# Just await directly — Jupyter cells are already async
-df = await blp.abdp(tickers='AAPL US Equity', flds=['PX_LAST', 'VOLUME'])
-
-# Concurrent requests work the same way
-import asyncio
-results = await asyncio.gather(
-    blp.abdp(tickers='AAPL US Equity', flds=['PX_LAST']),
-    blp.abdp(tickers='MSFT US Equity', flds=['PX_LAST']),
-)
+df = blp.bdp(tickers='AAPL US Equity', flds=['PX_LAST', 'VOLUME'])
+hist = blp.bdh(tickers='AAPL US Equity', flds='PX_LAST', start_date='2024-01-01')
 ```
 
-> **Tip:** If you don't need async, the sync functions (`bdp`, `bdh`, `bdib`, etc.) work everywhere — scripts, notebooks, and async contexts — without any special handling.
+`bdp`, `bdh`, `bds`, `bdib`, `bdtick`, and `request` use a notebook-only background event-loop bridge when IPykernel already has a loop running.
+
+If your notebook cell is already async, use the async APIs directly:
+
+```python
+from xbbg import blp
+
+df = await blp.abdp(tickers='AAPL US Equity', flds=['PX_LAST', 'VOLUME'])
+```
+
+> **Important:** Generic async applications such as FastAPI or ASGI services should still use `await blp.abdp(...)` / `await blp.abdh(...)`. The sync bridge is only for IPykernel notebook environments and does not apply to streaming or long-lived async APIs.
 
 **Benefits:**
-- Non-blocking: doesn't block the event loop
+- Non-blocking: async APIs don't block the event loop
 - Concurrent: use `asyncio.gather()` for parallel requests
-- Compatible: works with async web frameworks, Jupyter, and async codebases
-- Same API: identical parameters to sync versions (`bdp`, `bds`, `bdh`)
+- Compatible: async APIs work with web frameworks; one-shot sync APIs work in notebooks
+- Same API: identical parameters between sync and async versions (`bdp` / `abdp`, `bdh` / `abdh`)
 
 ### Multi-Backend Support
 

--- a/apps/xbbg-server/src/main.rs
+++ b/apps/xbbg-server/src/main.rs
@@ -18,6 +18,7 @@ use tokio::net::TcpListener;
 use tokio::sync::{broadcast, RwLock};
 use tower_http::cors::{Any, CorsLayer};
 use tower_http::trace::TraceLayer;
+use xbbg_async::engine::state::{subscription_update_to_record_batch, SubscriptionUpdate};
 use xbbg_async::engine::{
     Engine, EngineConfig, ExtractorType, OverflowPolicy, RequestParams, ServerAddr, Transport,
 };
@@ -667,8 +668,8 @@ async fn handle_subscription_socket(mut socket: WebSocket, state: AppState) {
             }
             maybe_batch = stream.next() => {
                 match maybe_batch {
-                    Some(Ok(batch)) => {
-                        match record_batch_to_json(&batch) {
+                    Some(Ok(update)) => {
+                        match subscription_update_to_json(&update) {
                             Ok(rows) => {
                                 if send_subscription_message(&mut socket, &SubscriptionServerMessage::Tick {
                                     subscription_id: subscription_id.clone(),
@@ -791,6 +792,11 @@ fn record_batch_to_json(batch: &RecordBatch) -> Result<Value, String> {
         .map_err(|error| format!("failed to finish Arrow JSON writer: {error}"))?;
     serde_json::from_slice(&buffer)
         .map_err(|error| format!("failed to decode Arrow JSON buffer: {error}"))
+}
+
+fn subscription_update_to_json(update: &SubscriptionUpdate) -> Result<Value, String> {
+    let batch = subscription_update_to_record_batch(update).map_err(core_error_to_string)?;
+    record_batch_to_json(&batch)
 }
 
 fn async_error_to_string(error: BlpAsyncError) -> String {

--- a/bindings/napi-xbbg/src/lib.rs
+++ b/bindings/napi-xbbg/src/lib.rs
@@ -1528,8 +1528,7 @@ impl JsSubscription {
                 tickers
                     .into_iter()
                     .filter(|ticker| {
-                        seen.insert(ticker.clone())
-                            && !snapshot.topic_to_key().contains_key(ticker)
+                        seen.insert(ticker.clone()) && !snapshot.topic_to_key().contains_key(ticker)
                     })
                     .collect()
             };

--- a/bindings/pyo3-xbbg/src/lib.rs
+++ b/bindings/pyo3-xbbg/src/lib.rs
@@ -1674,9 +1674,7 @@ impl SubscriptionStreamHandle {
         let snapshot = self.status.load();
         let new_topics: Vec<String> = tickers
             .into_iter()
-            .filter(|t| {
-                !snapshot.topic_to_key().contains_key(t) && seen_topics.insert(t.clone())
-            })
+            .filter(|t| !snapshot.topic_to_key().contains_key(t) && seen_topics.insert(t.clone()))
             .collect();
 
         if new_topics.is_empty() {
@@ -1806,8 +1804,7 @@ impl PySubscription {
                     topics: snapshot.topics().to_vec(),
                     fields: handle.fields.clone(),
                     is_active: snapshot.has_active_topics() && handle.claim.is_some(),
-                    all_failed: !snapshot.has_active_topics()
-                        && !snapshot.failures().is_empty(),
+                    all_failed: !snapshot.has_active_topics() && !snapshot.failures().is_empty(),
                     messages_received,
                     dropped_batches,
                     batches_sent,

--- a/crates/xbbg-async/src/engine/subscription_pool.rs
+++ b/crates/xbbg-async/src/engine/subscription_pool.rs
@@ -545,10 +545,7 @@ impl SubscriptionWorker {
                     let first_message = state.on_message(msg);
                     if first_message {
                         let topic = if let Some(status) = &self.status {
-                            let topic = status
-                                .load()
-                                .topic_for_key(key)
-                                .map(str::to_string);
+                            let topic = status.load().topic_for_key(key).map(str::to_string);
                             status.rcu(|current| {
                                 let mut next = (**current).clone();
                                 next.mark_topic_streaming(key);
@@ -772,8 +769,7 @@ impl SubscriptionWorker {
                         if self.subs.contains(key) {
                             if let Some(status) = &self.status {
                                 let snapshot = status.load();
-                                let topic =
-                                    snapshot.topic_for_key(key).map(|t| t.to_string());
+                                let topic = snapshot.topic_for_key(key).map(|t| t.to_string());
                                 let prev = topic.as_ref().and_then(|t| {
                                     snapshot
                                         .topic_statuses()
@@ -814,8 +810,7 @@ impl SubscriptionWorker {
                         if self.subs.contains(key) {
                             if let Some(status) = &self.status {
                                 let snapshot = status.load();
-                                let topic =
-                                    snapshot.topic_for_key(key).map(|t| t.to_string());
+                                let topic = snapshot.topic_for_key(key).map(|t| t.to_string());
                                 let prev = topic.as_ref().and_then(|t| {
                                     snapshot
                                         .topic_statuses()
@@ -1112,12 +1107,7 @@ impl SubscriptionWorker {
                     let has_active = !self.subs.is_empty();
                     status.rcu(|current| {
                         let mut next = (**current).clone();
-                        next.record_service_state(
-                            service_name.clone(),
-                            false,
-                            msg_type,
-                            None,
-                        );
+                        next.record_service_state(service_name.clone(), false, msg_type, None);
                         // Emit a subscription-category warning if we have active subs so
                         // callers polling subscription status (not just service status) see
                         // that their streams may be affected. The SDK will auto-recover
@@ -1148,12 +1138,7 @@ impl SubscriptionWorker {
                     let service_name = service.unwrap_or_else(|| "unknown".to_string());
                     status.rcu(|current| {
                         let mut next = (**current).clone();
-                        next.record_service_state(
-                            service_name.clone(),
-                            true,
-                            msg_type,
-                            None,
-                        );
+                        next.record_service_state(service_name.clone(), true, msg_type, None);
                         Arc::new(next)
                     });
                 }

--- a/crates/xbbg-bench/benches/lockfree_paths.rs
+++ b/crates/xbbg-bench/benches/lockfree_paths.rs
@@ -17,10 +17,10 @@ use std::sync::Arc;
 use arc_swap::ArcSwap;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 
+use xbbg_async::engine::state::SubscriptionMetrics;
 use xbbg_async::engine::{
     SharedSubscriptionStatus, SlabKey, SubscriptionEventLevel, SubscriptionStatusState,
 };
-use xbbg_async::engine::state::SubscriptionMetrics;
 use xbbg_async::field_cache::{FieldInfo, FieldTypeResolver};
 
 // ---------------------------------------------------------------------------
@@ -57,7 +57,9 @@ fn make_metrics() -> Arc<SubscriptionMetrics> {
 }
 
 fn make_status_state(n_topics: usize) -> SubscriptionStatusState {
-    let topics: Vec<String> = (0..n_topics).map(|i| format!("TOPIC{i} US Equity")).collect();
+    let topics: Vec<String> = (0..n_topics)
+        .map(|i| format!("TOPIC{i} US Equity"))
+        .collect();
     let keys: Vec<SlabKey> = (0..n_topics).collect();
     let metrics: HashMap<SlabKey, Arc<SubscriptionMetrics>> =
         keys.iter().map(|&k| (k, make_metrics())).collect();
@@ -149,9 +151,7 @@ fn bench_field_cache_resolve_types(c: &mut Criterion) {
     // 50 fields, all present in the 1000-entry cache.
     let fields: Vec<String> = (0..50).map(|i| format!("F{}", i * 10)).collect();
     group.bench_function("50_fields_on_1000_entry_cache", |b| {
-        b.iter(|| {
-            black_box(resolver.resolve_types(black_box(&fields), None, "float64"))
-        });
+        b.iter(|| black_box(resolver.resolve_types(black_box(&fields), None, "float64")));
     });
     group.finish();
 }
@@ -165,13 +165,17 @@ fn bench_status_load_topic_for_key(c: &mut Criterion) {
     for n_topics in [10, 50, 100] {
         let shared = make_shared_status(n_topics);
         let key: SlabKey = n_topics / 2;
-        group.bench_with_input(BenchmarkId::new("load_topic_for_key", n_topics), &n_topics, |b, _| {
-            b.iter(|| {
-                let snap = shared.load();
-                // Map to owned String to avoid returning a ref tied to the guard.
-                black_box(snap.topic_for_key(black_box(key)).map(str::to_string))
-            });
-        });
+        group.bench_with_input(
+            BenchmarkId::new("load_topic_for_key", n_topics),
+            &n_topics,
+            |b, _| {
+                b.iter(|| {
+                    let snap = shared.load();
+                    // Map to owned String to avoid returning a ref tied to the guard.
+                    black_box(snap.topic_for_key(black_box(key)).map(str::to_string))
+                });
+            },
+        );
     }
     group.finish();
 }

--- a/crates/xbbg-bench/benches/xbbg_benchmark_suite.rs
+++ b/crates/xbbg-bench/benches/xbbg_benchmark_suite.rs
@@ -25,6 +25,7 @@ use std::sync::Arc;
 use tokio::runtime::Runtime;
 use tokio::sync::{mpsc, oneshot};
 use xbbg_async::engine::state::typed_builder::{ArrowType, TypedBuilder};
+use xbbg_async::engine::state::SubscriptionUpdate;
 use xbbg_async::engine::{
     BqlState, BulkDataState, Engine, EngineConfig, ExtractorType, HistDataState, IntradayTickState,
     LongMode, OutputFormat, RefDataState, RequestParams, ServerAddr, SubscriptionState, Transport,
@@ -35,6 +36,10 @@ use xbbg_core::{
     BlpError, CorrelationId, DataType as BlpDataType, Element, Event, EventType, Message, Name,
     SubscriptionList,
 };
+
+fn subscription_update_shape(update: &SubscriptionUpdate) -> (usize, usize) {
+    (1, update.layout.fields.len() + 2)
+}
 struct TrackingAllocator;
 
 static TRACK_ALLOCATIONS: AtomicBool = AtomicBool::new(false);
@@ -2969,11 +2974,12 @@ fn replay_subscription_events(
     let mut columns = 0usize;
     let mut batches = 0usize;
     while let Ok(item) = rx.try_recv() {
-        if let Ok(batch) = item {
-            rows += batch.num_rows();
-            columns = columns.max(batch.num_columns());
+        if let Ok(update) = item {
+            let (update_rows, update_columns) = subscription_update_shape(&update);
+            rows += update_rows;
+            columns = columns.max(update_columns);
             batches += 1;
-            black_box(batch);
+            black_box(update);
         }
     }
     let drain_elapsed = drain_start.elapsed();
@@ -3092,9 +3098,10 @@ async fn live_subscription(engine: &Engine, collect_ms: u64) -> BenchRecord {
     while Instant::now() < deadline {
         let remaining = deadline.saturating_duration_since(Instant::now());
         match tokio::time::timeout(remaining, stream.next()).await {
-            Ok(Some(Ok(batch))) => {
+            Ok(Some(Ok(update))) => {
+                let (update_rows, _) = subscription_update_shape(&update);
                 batches += 1;
-                rows += batch.num_rows();
+                rows += update_rows;
             }
             Ok(Some(Err(err))) => {
                 let _ = stream.unsubscribe(true).await;

--- a/crates/xbbg-core/src/request.rs
+++ b/crates/xbbg-core/src/request.rs
@@ -818,6 +818,19 @@ fn parse_datetime(s: &str) -> Result<crate::ffi::blpapi_Datetime_t> {
     Ok(dt)
 }
 
+impl Drop for Request {
+    fn drop(&mut self) {
+        if !self.ptr.is_null() {
+            // SAFETY: We own this pointer and it's valid.
+            // blpapi_Request_destroy releases the request resources.
+            unsafe {
+                crate::ffi::blpapi_Request_destroy(self.ptr);
+            }
+            self.ptr = std::ptr::null_mut();
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -849,18 +862,5 @@ mod tests {
         assert_eq!(dt.seconds, 3);
         assert_eq!(dt.offset, 0);
         assert!(dt.parts & crate::ffi::BLPAPI_DATETIME_OFFSET_PART != 0);
-    }
-}
-
-impl Drop for Request {
-    fn drop(&mut self) {
-        if !self.ptr.is_null() {
-            // SAFETY: We own this pointer and it's valid.
-            // blpapi_Request_destroy releases the request resources.
-            unsafe {
-                crate::ffi::blpapi_Request_destroy(self.ptr);
-            }
-            self.ptr = std::ptr::null_mut();
-        }
     }
 }

--- a/docs/src/content/docs/python/guides/async.mdx
+++ b/docs/src/content/docs/python/guides/async.mdx
@@ -88,24 +88,28 @@ configure(request_pool_size=4)
 
 ## Jupyter notebooks
 
-Jupyter already runs an event loop. Calling `asyncio.run()` inside a notebook cell raises `RuntimeError: asyncio.run() cannot be called from a running event loop`. Use `await` directly instead:
+Jupyter and VS Code Interactive run an IPykernel event loop. For one-shot request/response APIs, the sync wrappers keep the familiar Bloomberg syntax working by using a notebook-only background event-loop bridge:
 
 ```python
 from xbbg import blp
 
-# Single request — await directly in the cell
-df = await blp.abdp(tickers='AAPL US Equity', flds=['PX_LAST', 'VOLUME'])
-
-# Concurrent requests work the same way
-import asyncio
-results = await asyncio.gather(
-    blp.abdp(tickers='AAPL US Equity', flds=['PX_LAST']),
-    blp.abdp(tickers='MSFT US Equity', flds=['PX_LAST']),
-)
+# Sync one-shot calls work in notebook cells
+df = blp.bdp(tickers='AAPL US Equity', flds=['PX_LAST', 'VOLUME'])
+hist = blp.bdh(tickers='AAPL US Equity', flds=['PX_LAST'], start_date='2024-01-01')
 ```
 
-<Aside type="tip">
-Jupyter's top-level `await` support is enabled automatically. No cell magic or helper libraries are needed.
+The bridge applies to `bdp`, `bdh`, `bds`, `bdib`, `bdtick`, and `request`. It preserves scoped `xbbg.Engine(...)` context across the background thread and propagates exceptions back to the cell.
+
+If you are already writing async notebook code, keep using top-level `await`:
+
+```python
+from xbbg import blp
+
+df = await blp.abdp(tickers='AAPL US Equity', flds=['PX_LAST', 'VOLUME'])
+```
+
+<Aside type="caution">
+The notebook bridge is not a generic async escape hatch. FastAPI, ASGI services, task workers, and other async applications should use the `a`-prefixed APIs directly. Streaming and long-lived lifecycle APIs also remain explicitly async-aware.
 </Aside>
 
 ## GIL release
@@ -198,10 +202,10 @@ results = await asyncio.gather(
 ```
 
 **Use async when integrating with async frameworks.**
-If you are building a FastAPI service, async task queue, or other async application, prefer the `a`-prefixed functions — they participate in the event loop without blocking it. The sync wrappers call `asyncio.run()` internally, which starts a new event loop and cannot be called from within an existing one.
+If you are building a FastAPI service, ASGI app, async task queue, or other async application, prefer the `a`-prefixed functions — they participate in the event loop without blocking it. Sync wrappers still raise in these generic async contexts and direct you to `await abdp(...)`, `await abdh(...)`, and the other async APIs.
 
-**Sync functions work everywhere else.**
-If your script is sequential and you have no async requirements, the sync functions (`bdp`, `bdh`, `bdib`, etc.) are fully supported in scripts, notebooks, and modules. There is no performance penalty for using sync in non-async contexts.
+**Sync functions work in scripts and notebooks.**
+If your script is sequential and you have no async requirements, the sync functions (`bdp`, `bdh`, `bdib`, etc.) are fully supported. In IPykernel notebooks and VS Code Interactive, one-shot sync calls use a background loop bridge; outside notebooks, sync wrappers use `asyncio.run()`.
 
 **Match pool size to workload.**
 The default `request_pool_size=2` is appropriate for most workloads. If you are issuing many concurrent `gather()` calls with large fan-outs, raise it — but Bloomberg API servers also have per-connection limits, so test before committing to a large value.

--- a/py-xbbg/src/xbbg/_core/__init__.pyi
+++ b/py-xbbg/src/xbbg/_core/__init__.pyi
@@ -711,6 +711,10 @@ class PySubscription:
         Raises a Python exception (BlpRequestError, BlpInternalError, etc.) on error.
         Raises StopAsyncIteration when the subscription is closed.
         """
+    def __anext_tick_dict__(self) -> typing.Any:
+        r"""
+        Get next update as a Python dict without building Arrow.
+        """
     def add(self, tickers: typing.Sequence[builtins.str]) -> typing.Any:
         r"""
         Add tickers to the subscription dynamically.

--- a/py-xbbg/src/xbbg/blp.py
+++ b/py-xbbg/src/xbbg/blp.py
@@ -5,7 +5,7 @@ with support for multiple DataFrame backends via narwhals.
 
 API Design:
 - Async-first: Core implementation uses async/await (abdp, abdh, etc.)
-- Sync wrappers: Convenience functions (bdp, bdh, etc.) wrap async with asyncio.run()
+- Sync wrappers: Convenience functions wrap async with asyncio.run(), with a notebook bridge for one-shot requests
 - Generic API: arequest() and request() for power users and arbitrary Bloomberg requests
 - Users can use either style based on their needs
 """
@@ -15,6 +15,7 @@ from __future__ import annotations
 import asyncio
 import atexit
 from collections.abc import Awaitable, Callable, Sequence
+import concurrent.futures
 import contextvars
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
@@ -280,6 +281,11 @@ _engine_lock = threading.Lock()
 # Scoped engine for multi-engine routing (async-safe via contextvars)
 _active_engine: contextvars.ContextVar[Engine | None] = contextvars.ContextVar("_active_engine", default=None)
 
+_NOTEBOOK_SYNC_BRIDGE_NAMES = frozenset({"bdp", "bdh", "bds", "bdib", "bdtick", "request"})
+_notebook_sync_loop: asyncio.AbstractEventLoop | None = None
+_notebook_sync_loop_thread: threading.Thread | None = None
+_notebook_sync_loop_lock = threading.Lock()
+
 
 class Engine:
     """Non-global Bloomberg engine for multi-source routing.
@@ -451,6 +457,12 @@ def _atexit_cleanup() -> None:
         except Exception:
             logger.debug("Exception during atexit cleanup (ignored)", exc_info=True)
         _engine = None
+    stop_bridge = globals().get("_stop_notebook_sync_loop")
+    if stop_bridge is not None:
+        try:
+            stop_bridge()
+        except Exception:
+            logger.debug("Exception stopping notebook sync bridge (ignored)", exc_info=True)
 
 
 # Register cleanup handler
@@ -1491,11 +1503,132 @@ def _strip_signature_annotations(func: Callable[..., Any]) -> str:
     return str(stripped)
 
 
+def _is_notebook_context() -> bool:
+    """Return True when running in an IPykernel-backed notebook shell."""
+    try:
+        from IPython import get_ipython
+    except Exception:
+        return False
+
+    shell = get_ipython()
+    if shell is None:
+        return False
+
+    shell_module = shell.__class__.__module__
+    if shell_module.startswith("ipykernel."):
+        return True
+
+    config = getattr(shell, "config", None)
+    return bool(config is not None and "IPKernelApp" in config)
+
+
+def _ensure_notebook_sync_loop() -> asyncio.AbstractEventLoop:
+    global _notebook_sync_loop, _notebook_sync_loop_thread
+
+    with _notebook_sync_loop_lock:
+        if (
+            _notebook_sync_loop is not None
+            and not _notebook_sync_loop.is_closed()
+            and _notebook_sync_loop.is_running()
+            and _notebook_sync_loop_thread is not None
+            and _notebook_sync_loop_thread.is_alive()
+        ):
+            return _notebook_sync_loop
+
+        ready = threading.Event()
+        loop_holder: dict[str, asyncio.AbstractEventLoop] = {}
+        error_holder: list[Exception] = []
+
+        def run_loop() -> None:
+            try:
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+                loop_holder["loop"] = loop
+                loop.call_soon(ready.set)
+                loop.run_forever()
+                pending = asyncio.all_tasks(loop)
+                for task in pending:
+                    task.cancel()
+                if pending:
+                    loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+                loop.run_until_complete(loop.shutdown_asyncgens())
+                loop.close()
+            except Exception as exc:
+                error_holder.append(exc)
+                ready.set()
+
+        thread = threading.Thread(
+            target=run_loop,
+            name="xbbg-notebook-sync-bridge",
+            daemon=True,
+        )
+        thread.start()
+        ready.wait()
+
+        if error_holder:
+            raise RuntimeError("Failed to start xbbg notebook sync bridge") from error_holder[0]
+
+        _notebook_sync_loop = loop_holder["loop"]
+        _notebook_sync_loop_thread = thread
+        return _notebook_sync_loop
+
+
+def _stop_notebook_sync_loop() -> None:
+    global _notebook_sync_loop, _notebook_sync_loop_thread
+
+    with _notebook_sync_loop_lock:
+        loop = _notebook_sync_loop
+        thread = _notebook_sync_loop_thread
+        _notebook_sync_loop = None
+        _notebook_sync_loop_thread = None
+
+    if loop is not None and loop.is_running():
+        loop.call_soon_threadsafe(loop.stop)
+    if thread is not None and thread.is_alive() and thread is not threading.current_thread():
+        thread.join(timeout=1.0)
+
+
+def _run_in_notebook_sync_bridge(
+    async_func: Callable[..., Any],
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> Any:
+    if _notebook_sync_loop_thread is threading.current_thread():
+        raise RuntimeError("xbbg notebook sync bridge cannot be re-entered from its own event-loop thread")
+
+    loop = _ensure_notebook_sync_loop()
+    caller_context = contextvars.copy_context()
+    result: concurrent.futures.Future = concurrent.futures.Future()
+
+    def schedule() -> None:
+        try:
+            task = asyncio.ensure_future(async_func(*args, **kwargs))
+        except Exception as exc:
+            result.set_exception(exc)
+            return
+
+        def complete(task: asyncio.Future) -> None:
+            if result.cancelled():
+                return
+            try:
+                result.set_result(task.result())
+            except asyncio.CancelledError as exc:
+                result.set_exception(exc)
+            except Exception as exc:
+                result.set_exception(exc)
+
+        task.add_done_callback(complete)
+
+    loop.call_soon_threadsafe(schedule, context=caller_context)
+    return result.result()
+
+
 def _build_sync_wrapper(
     sync_name: str,
     async_func: Callable[..., Any],
     *,
     template: Callable[..., Any] | None = None,
+    allow_notebook_bridge: bool = False,
 ) -> Callable[..., Any]:
     template_func = template if template is not None else async_func
 
@@ -1504,15 +1637,16 @@ def _build_sync_wrapper(
         try:
             asyncio.get_running_loop()
         except RuntimeError:
-            pass  # No running loop — asyncio.run() is safe
-        else:
-            raise RuntimeError(
-                f"{sync_name}() cannot be used inside an async context "
-                f"(FastAPI, Jupyter, etc.). "
-                f"Use 'await a{sync_name}()' instead, "
-                f"or use xbbg.Engine(...) for scoped async engines."
-            )
-        return asyncio.run(async_func(*args, **kwargs))
+            return asyncio.run(async_func(*args, **kwargs))
+
+        if allow_notebook_bridge and _is_notebook_context():
+            return _run_in_notebook_sync_bridge(async_func, args, kwargs)
+
+        raise RuntimeError(
+            f"{sync_name}() cannot be used inside an async context. "
+            f"Use 'await a{sync_name}()' instead, "
+            f"or use xbbg.Engine(...) for scoped async engines."
+        )
 
     wrapped.__name__ = sync_name
     wrapped.__qualname__ = sync_name
@@ -1572,7 +1706,12 @@ def _install_generated_endpoint(spec: _GeneratedEndpointSpec) -> None:
     generated_async = _build_generated_async(spec, async_template)
     globals()[spec.async_name] = generated_async
 
-    globals()[spec.sync_name] = _build_sync_wrapper(spec.sync_name, generated_async, template=async_template)
+    globals()[spec.sync_name] = _build_sync_wrapper(
+        spec.sync_name,
+        generated_async,
+        template=async_template,
+        allow_notebook_bridge=spec.sync_name in _NOTEBOOK_SYNC_BRIDGE_NAMES,
+    )
 
 
 def _install_generated_endpoints() -> None:
@@ -4021,7 +4160,11 @@ def _install_manual_sync_wrappers() -> None:
         ("bops", abops),
         ("bschema", abschema),
     ):
-        globals()[sync_name] = _build_sync_wrapper(sync_name, async_func)
+        globals()[sync_name] = _build_sync_wrapper(
+            sync_name,
+            async_func,
+            allow_notebook_bridge=sync_name in _NOTEBOOK_SYNC_BRIDGE_NAMES,
+        )
 
 
 _install_manual_sync_wrappers()

--- a/py-xbbg/src/xbbg/blp.py
+++ b/py-xbbg/src/xbbg/blp.py
@@ -2024,10 +2024,7 @@ async def asubscribe(
     if output is not None:
         normalized_output = output.lower()
         if normalized_output not in ("record_batch", "backend", "dict", "tick"):
-            raise ValueError(
-                "output must be one of 'record_batch', 'backend', 'dict', 'tick', "
-                f"got {output!r}"
-            )
+            raise ValueError(f"output must be one of 'record_batch', 'backend', 'dict', 'tick', got {output!r}")
         if normalized_output in ("dict", "tick"):
             tick_mode = True
         elif normalized_output == "record_batch":

--- a/py-xbbg/tests/live/test_api.py
+++ b/py-xbbg/tests/live/test_api.py
@@ -319,6 +319,59 @@ class TestAbdh:
 
 
 # =============================================================================
+# Notebook Sync Bridge Regression Tests
+# =============================================================================
+
+
+class TestNotebookSyncBridge:
+    """Live regression coverage for issue #281 notebook sync wrappers."""
+
+    @staticmethod
+    def _enable_fake_ipykernel(IPython):
+        class FakeKernelShell:
+            __module__ = "ipykernel.zmqshell"
+
+            config = {"IPKernelApp": {}}
+
+        original_get_ipython = IPython.get_ipython
+        IPython.get_ipython = lambda: FakeKernelShell()
+        return original_get_ipython
+
+    @pytest.mark.asyncio
+    async def test_bdp_bdh_sync_wrappers_work_in_ipykernel_loop(self):
+        """bdp/bdh should work from a running IPykernel event loop."""
+        IPython = pytest.importorskip("IPython")
+        from xbbg import bdh, bdp, blp
+
+        original_get_ipython = self._enable_fake_ipykernel(IPython)
+        try:
+            bdp_df = bdp(CONFIG.equity_single, CONFIG.price_field)
+            start, end = get_date_range(5)
+            bdh_df = bdh(CONFIG.equity_single, CONFIG.price_field, start_date=start, end_date=end)
+        finally:
+            IPython.get_ipython = original_get_ipython
+            blp._stop_notebook_sync_loop()
+
+        assert len(bdp_df) == 1
+        assert len(bdh_df) >= 1
+        logger.info(f"  Notebook bridge bdp rows: {len(bdp_df)}, bdh rows: {len(bdh_df)}")
+
+    @pytest.mark.asyncio
+    async def test_streaming_sync_wrapper_still_raises_in_notebook_loop(self):
+        """Streaming sync wrappers stay async-aware and do not use the notebook bridge."""
+        IPython = pytest.importorskip("IPython")
+        from xbbg import blp, subscribe
+
+        original_get_ipython = self._enable_fake_ipykernel(IPython)
+        try:
+            with pytest.raises(RuntimeError, match="await asubscribe"):
+                subscribe([CONFIG.streaming_ticker], [CONFIG.price_field])
+        finally:
+            IPython.get_ipython = original_get_ipython
+            blp._stop_notebook_sync_loop()
+
+
+# =============================================================================
 # Output Format Tests - regression coverage for bdp/bdh format= variants
 # =============================================================================
 
@@ -2024,6 +2077,7 @@ _register_class_tests(TestBdp, "bdp")
 _register_class_tests(TestAbdp, "abdp")
 _register_class_tests(TestBdh, "bdh")
 _register_class_tests(TestAbdh, "abdh")
+_register_class_tests(TestNotebookSyncBridge, "notebook_bridge")
 _register_class_tests(TestBds, "bds")
 _register_class_tests(TestAbds, "abds")
 _register_class_tests(TestBdib, "bdib")
@@ -2101,6 +2155,7 @@ def run_tests(test_names: list[str]) -> bool:
                     "abdib",
                     "abdtick",
                     "ext_async",
+                    "notebook_bridge",
                     "stream",
                     "abql",
                     "absrch",

--- a/py-xbbg/tests/live/test_subscription_fixes.py
+++ b/py-xbbg/tests/live/test_subscription_fixes.py
@@ -294,7 +294,8 @@ async def test_schema_types():
                 {
                     field.name: batch.column(field.name)[0].as_py()
                     for field in batch.schema
-                    if field.name in {
+                    if field.name
+                    in {
                         "timestamp",
                         "topic",
                         "LAST_PRICE",

--- a/py-xbbg/tests/test_blp.py
+++ b/py-xbbg/tests/test_blp.py
@@ -5,8 +5,109 @@ These tests verify the Python API without requiring a Bloomberg connection.
 
 from __future__ import annotations
 
+import asyncio
+import contextvars
 import inspect
 from pathlib import Path
+import threading
+
+import pytest
+
+
+class TestNotebookSyncBridge:
+    """Tests for sync wrappers called from running event loops."""
+
+    def test_generic_async_context_still_raises(self, monkeypatch):
+        """Non-notebook async callers should be directed to the async API."""
+        from xbbg import blp
+
+        async def fake_request():
+            return "ok"
+
+        wrapper = blp._build_sync_wrapper("bdp", fake_request, allow_notebook_bridge=True)
+        monkeypatch.setattr(blp, "_is_notebook_context", lambda: False)
+
+        async def call_wrapper():
+            wrapper()
+
+        with pytest.raises(RuntimeError, match="await abdp"):
+            asyncio.run(call_wrapper())
+
+    def test_notebook_context_uses_background_loop_and_preserves_contextvars(self, monkeypatch):
+        """Notebook callers should block on a background loop without losing context."""
+        from xbbg import blp
+
+        scoped_value = contextvars.ContextVar("scoped_value", default="missing")
+
+        async def fake_request():
+            return scoped_value.get(), threading.current_thread().name
+
+        wrapper = blp._build_sync_wrapper("bdp", fake_request, allow_notebook_bridge=True)
+        monkeypatch.setattr(blp, "_is_notebook_context", lambda: True)
+        token = scoped_value.set("active-engine")
+
+        async def call_wrapper():
+            return wrapper()
+
+        try:
+            value, thread_name = asyncio.run(call_wrapper())
+        finally:
+            scoped_value.reset(token)
+            blp._stop_notebook_sync_loop()
+
+        assert value == "active-engine"
+        assert thread_name == "xbbg-notebook-sync-bridge"
+
+    def test_notebook_context_propagates_async_exceptions(self, monkeypatch):
+        """Async failures should surface unchanged to the sync caller."""
+        from xbbg import blp
+
+        class ExpectedError(Exception):
+            pass
+
+        async def fake_request():
+            raise ExpectedError("boom")
+
+        wrapper = blp._build_sync_wrapper("bdh", fake_request, allow_notebook_bridge=True)
+        monkeypatch.setattr(blp, "_is_notebook_context", lambda: True)
+
+        async def call_wrapper():
+            wrapper()
+
+        try:
+            with pytest.raises(ExpectedError, match="boom"):
+                asyncio.run(call_wrapper())
+        finally:
+            blp._stop_notebook_sync_loop()
+
+    def test_public_bridge_scope_is_one_shot_only(self, monkeypatch):
+        """Installed public wrappers should bridge one-shot APIs, not streams."""
+        from xbbg import blp
+
+        def fake_bridge(async_func, args, kwargs):
+            return async_func.__name__, args, kwargs
+
+        monkeypatch.setattr(blp, "_is_notebook_context", lambda: True)
+        monkeypatch.setattr(blp, "_run_in_notebook_sync_bridge", fake_bridge)
+
+        async def call_bdp():
+            return blp.bdp("AAPL US Equity", "PX_LAST")
+
+        async def call_request():
+            return blp.request(service="//blp/refdata", operation="ReferenceDataRequest")
+
+        async def call_subscribe():
+            blp.subscribe(["AAPL US Equity"], ["LAST_PRICE"])
+
+        bdp_name, bdp_args, _ = asyncio.run(call_bdp())
+        request_name, _, request_kwargs = asyncio.run(call_request())
+
+        assert bdp_name == "abdp"
+        assert bdp_args == ("AAPL US Equity", "PX_LAST")
+        assert request_name == "arequest"
+        assert request_kwargs["service"] == "//blp/refdata"
+        with pytest.raises(RuntimeError, match="await asubscribe"):
+            asyncio.run(call_subscribe())
 
 
 class TestBdp:


### PR DESCRIPTION
Fixes #281.\n\n## Summary\n- Add a notebook-only sync bridge backed by a dedicated background asyncio loop for one-shot wrappers: bdp, bdh, bds, bdib, bdtick, and request.\n- Preserve contextvars across the thread boundary and propagate async exceptions to sync callers.\n- Keep generic async contexts and streaming/long-lived sync wrappers async-only, and update docs plus unit/live coverage.\n\n## Testing\n- pixi run install\n- pixi run -e lint ruff check py-xbbg/src/xbbg/blp.py py-xbbg/tests/test_blp.py py-xbbg/tests/live/test_api.py\n- pixi run -e test pytest py-xbbg/tests/test_blp.py -ra -q\n- powershell -NoProfile -Command ':CI=; pixi run pytest py-xbbg/tests/live/test_api.py::TestNotebookSyncBridge -ra -q'\n- pixi run -e docs docs-install\n- pixi run -e docs npm run astro -- check\n\nNote: pixi run -e docs docs-check is blocked on this workstation because its content-generation scripts invoke bash through WSL, and WSL has no installed distributions here. The direct astro check passed after installing docs deps via pixi.