### PR TITLE
Implement update-first subscription streaming

### DIFF
--- a/bindings/napi-xbbg/src/lib.rs
+++ b/bindings/napi-xbbg/src/lib.rs
@@ -14,6 +14,9 @@ use arrow_zero_copy::NativeArrowBatch;
 use napi::bindgen_prelude::{Buffer, Error, Status};
 use napi_derive::napi;
 use tokio::sync::{Mutex, Notify};
+use xbbg_async::engine::state::{
+    subscription_update_to_record_batch, SubscriptionUpdate, UpdateValue,
+};
 use xbbg_async::engine::{
     Engine, EngineConfig, ExtractorType, OverflowPolicy, RequestParams, ServerAddr,
     SharedSubscriptionStatus, Socks5Proxy, TlsConfig, Transport,
@@ -21,7 +24,7 @@ use xbbg_async::engine::{
 use xbbg_async::{BlpAsyncError, ValidationMode};
 use xbbg_core::{AuthConfig, BlpError};
 
-type StreamBatchResult = std::result::Result<RecordBatch, BlpError>;
+type StreamBatchResult = std::result::Result<SubscriptionUpdate, BlpError>;
 type StreamReceiver = tokio::sync::mpsc::Receiver<StreamBatchResult>;
 type SharedStreamReceiver = Arc<Mutex<Option<StreamReceiver>>>;
 
@@ -160,6 +163,18 @@ pub struct SubscriptionStats {
     pub dropped_batches: i64,
     pub batches_sent: i64,
     pub slow_consumer: bool,
+}
+
+#[napi(object)]
+pub struct NativeSubscriptionUpdate {
+    pub kind: String,
+    pub topic: String,
+    pub topic_id: u32,
+    pub timestamp_us: i64,
+    pub layout_version: u32,
+    pub fields: Vec<String>,
+    pub values: Vec<serde_json::Value>,
+    pub value_kinds: Vec<String>,
 }
 
 fn to_i64_saturating(value: u64) -> i64 {
@@ -661,8 +676,63 @@ fn to_ipc_buffer(batch: RecordBatch) -> napi::Result<Buffer> {
     Ok(Buffer::from(cursor.into_inner()))
 }
 
-fn to_native_arrow(batch: RecordBatch) -> napi::Result<NativeArrowBatch> {
+fn to_native_arrow(update: SubscriptionUpdate) -> napi::Result<NativeArrowBatch> {
+    let batch = subscription_update_to_record_batch(&update).map_err(blp_error_to_napi)?;
     NativeArrowBatch::from_record_batch(batch)
+}
+
+fn to_native_update(update: SubscriptionUpdate) -> NativeSubscriptionUpdate {
+    let mut fields = Vec::with_capacity(update.values.len());
+    let mut values = Vec::with_capacity(update.values.len());
+    let mut value_kinds = Vec::with_capacity(update.values.len());
+    for field in update.values.iter() {
+        let Some(meta) = update.layout.fields.get(field.index as usize) else {
+            continue;
+        };
+        fields.push(meta.name.to_string());
+        values.push(update_value_to_json(&field.value));
+        value_kinds.push(update_value_kind(&field.value).to_string());
+    }
+    NativeSubscriptionUpdate {
+        kind: "update".to_string(),
+        topic: update.topic.to_string(),
+        topic_id: update.topic_id,
+        timestamp_us: update.timestamp_us,
+        layout_version: update.layout.version,
+        fields,
+        values,
+        value_kinds,
+    }
+}
+
+fn update_value_kind(value: &UpdateValue) -> &'static str {
+    match value {
+        UpdateValue::Null => "null",
+        UpdateValue::Bool(_) => "bool",
+        UpdateValue::I32(_) => "i32",
+        UpdateValue::I64(_) => "i64",
+        UpdateValue::F64(_) => "f64",
+        UpdateValue::Str(_) => "str",
+        UpdateValue::Date32(_) => "date32",
+        UpdateValue::Time64Micros(_) => "time64_us",
+        UpdateValue::TimestampMicros(_) => "timestamp_us",
+    }
+}
+
+fn update_value_to_json(value: &UpdateValue) -> serde_json::Value {
+    match value {
+        UpdateValue::Null => serde_json::Value::Null,
+        UpdateValue::Bool(v) => serde_json::Value::Bool(*v),
+        UpdateValue::I32(v) => serde_json::Value::Number((*v).into()),
+        UpdateValue::I64(v) => serde_json::Value::String(v.to_string()),
+        UpdateValue::F64(v) => serde_json::Number::from_f64(*v)
+            .map(serde_json::Value::Number)
+            .unwrap_or(serde_json::Value::Null),
+        UpdateValue::Str(v) => serde_json::Value::String(v.to_string()),
+        UpdateValue::Date32(v) => serde_json::Value::Number((*v).into()),
+        UpdateValue::Time64Micros(v) => serde_json::Value::String(v.to_string()),
+        UpdateValue::TimestampMicros(v) => serde_json::Value::String(v.to_string()),
+    }
 }
 
 fn blp_error_to_napi(e: BlpError) -> Error {
@@ -1366,6 +1436,38 @@ impl JsSubscription {
     }
 
     #[napi]
+    pub async fn next_update(&self) -> napi::Result<Option<NativeSubscriptionUpdate>> {
+        if self.closed.load(Ordering::Acquire) {
+            return Ok(None);
+        }
+        let mut rx = {
+            let mut guard = self.rx.lock().await;
+            guard
+                .take()
+                .ok_or_else(|| Error::new(Status::GenericFailure, "subscription receiver busy"))?
+        };
+
+        let item = tokio::select! {
+            item = rx.recv() => item,
+            _ = self.close_notify.notified() => None,
+        };
+
+        {
+            let mut guard = self.rx.lock().await;
+            if guard.is_none() {
+                *guard = Some(rx);
+                self.rx_available.notify_waiters();
+            }
+        }
+
+        match item {
+            Some(Ok(update)) => Ok(Some(to_native_update(update))),
+            Some(Err(e)) => Err(blp_error_to_napi(e)),
+            None => Ok(None),
+        }
+    }
+
+    #[napi]
     pub async fn next_arrow(&self) -> napi::Result<Option<NativeArrowBatch>> {
         if self.closed.load(Ordering::Acquire) {
             return Ok(None);
@@ -1603,6 +1705,79 @@ impl JsSubscription {
     }
 
     #[napi]
+    pub async fn unsubscribe(
+        &self,
+        drain: Option<bool>,
+    ) -> napi::Result<Option<Vec<NativeSubscriptionUpdate>>> {
+        let _mutation = self.mutation.lock().await;
+        self.closed.store(true, Ordering::Release);
+        let drain = drain.unwrap_or(false);
+        let handle = {
+            let mut guard = self.stream.lock().await;
+            guard.take()
+        };
+
+        self.close_notify.notify_waiters();
+
+        let mut unsubscribe_result = Ok(());
+        let had_handle = handle.is_some();
+        if let Some(mut handle) = handle {
+            let status = handle.status.clone();
+            let keys = status.lock().keys().to_vec();
+            let claim = handle.claim.take();
+            drop(handle);
+
+            if let Some(claim) = claim {
+                if !keys.is_empty() {
+                    match claim
+                        .unsubscribe(keys)
+                        .await
+                        .map_err(blp_async_error_to_napi)
+                    {
+                        Ok(()) => status.lock().clear_active(),
+                        Err(err) => unsubscribe_result = Err(err),
+                    }
+                } else {
+                    status.lock().clear_active();
+                }
+            }
+        }
+
+        let rx = loop {
+            let notified = self.rx_available.notified();
+            if let Some(rx) = {
+                let mut guard = self.rx.lock().await;
+                guard.take()
+            } {
+                break Some(rx);
+            }
+            if !had_handle {
+                break None;
+            }
+            notified.await;
+        };
+
+        let mut remaining = Vec::new();
+        if let Some(mut rx) = rx {
+            if drain {
+                while let Ok(item) = rx.try_recv() {
+                    if let Ok(update) = item {
+                        remaining.push(to_native_update(update));
+                    }
+                }
+            }
+        }
+
+        unsubscribe_result?;
+
+        if remaining.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(remaining))
+        }
+    }
+
+    #[napi]
     pub async fn unsubscribe_arrow(
         &self,
         drain: Option<bool>,
@@ -1627,13 +1802,18 @@ impl JsSubscription {
 
             if let Some(claim) = claim {
                 if !keys.is_empty() {
-                    unsubscribe_result = claim
+                    match claim
                         .unsubscribe(keys)
                         .await
-                        .map_err(blp_async_error_to_napi);
+                        .map_err(blp_async_error_to_napi)
+                    {
+                        Ok(()) => status.lock().clear_active(),
+                        Err(err) => unsubscribe_result = Err(err),
+                    }
+                } else {
+                    status.lock().clear_active();
                 }
             }
-            status.lock().clear_active();
         }
 
         let rx = loop {

--- a/bindings/pyo3-xbbg/src/lib.rs
+++ b/bindings/pyo3-xbbg/src/lib.rs
@@ -45,16 +45,18 @@ use std::collections::{HashMap, HashSet};
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
-use chrono::NaiveDate;
+use chrono::{DateTime, Datelike, NaiveDate, Timelike};
 use pyo3::exceptions::{PyRuntimeError, PyStopAsyncIteration, PyValueError};
 use pyo3::prelude::*;
-use pyo3::types::PyDict;
+use pyo3::types::{PyDate, PyDateTime, PyDict, PyTime};
 use pyo3_async_runtimes::tokio::future_into_py;
 use pyo3_stub_gen::{define_stub_info_gatherer, derive::*};
 use tokio::sync::{watch, Mutex};
 use xbbg_log::{debug, info, warn};
 
-use xbbg_async::engine::state::SubscriptionMetrics;
+use xbbg_async::engine::state::{
+    subscription_update_to_record_batch, SubscriptionMetrics, SubscriptionUpdate, UpdateValue,
+};
 use xbbg_async::engine::{
     AdminStatusInfo, Engine, EngineConfig, ExtractorType, RequestParams, RetryPolicy, ServerAddr,
     ServiceStatusInfo, SessionStatusInfo, Socks5Proxy, SubscriptionCommandHandle,
@@ -68,7 +70,7 @@ mod ext;
 mod markets;
 mod recipes;
 
-type StreamBatchResult = Result<arrow::record_batch::RecordBatch, BlpError>;
+type StreamBatchResult = Result<SubscriptionUpdate, BlpError>;
 type StreamSender = tokio::sync::mpsc::Sender<StreamBatchResult>;
 type StreamReceiver = tokio::sync::mpsc::Receiver<StreamBatchResult>;
 type SharedStreamReceiver = Arc<Mutex<Option<StreamReceiver>>>;
@@ -1864,8 +1866,39 @@ impl PySubscription {
             };
 
             match item {
-                Ok(Some(Ok(batch))) => {
-                    try_attach_or_suspend(|py| record_batch_to_pyarrow(py, batch)).await
+                Ok(Some(Ok(update))) => {
+                    try_attach_or_suspend(|py| subscription_update_to_pyarrow(py, update)).await
+                }
+                Ok(Some(Err(blp_err))) => Err(blp_error_to_pyerr(blp_err)),
+                Ok(None) => Err(PyStopAsyncIteration::new_err("subscription ended")),
+                Err(()) => Err(PyStopAsyncIteration::new_err("subscription closed")),
+            }
+        })
+    }
+
+    /// Get next update as a Python dict without building Arrow.
+    fn __anext_tick_dict__<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let rx = self.rx.clone();
+        let close_signal = self.close_signal.clone();
+        let mut engine_shutdown_rx = self.engine_shutdown.clone();
+
+        future_into_py(py, async move {
+            let mut close_rx = close_signal.subscribe();
+            let item = {
+                let mut guard = rx.lock().await;
+                let rx_ref = guard
+                    .as_mut()
+                    .ok_or_else(|| PyStopAsyncIteration::new_err("subscription closed"))?;
+                tokio::select! {
+                    item = rx_ref.recv() => Ok(item),
+                    _ = wait_for_subscription_close(&mut close_rx) => Err(()),
+                    _ = engine_shutdown_rx.changed() => Err(()),
+                }
+            };
+
+            match item {
+                Ok(Some(Ok(update))) => {
+                    try_attach_or_suspend(|py| subscription_update_to_pydict(py, update)).await
                 }
                 Ok(Some(Err(blp_err))) => Err(blp_error_to_pyerr(blp_err)),
                 Ok(None) => Err(PyStopAsyncIteration::new_err("subscription ended")),
@@ -2136,7 +2169,7 @@ impl PySubscription {
 
             let mut remaining = Vec::new();
 
-            // Drain remaining batches if requested (skip errors)
+            // Drain remaining updates if requested (skip errors)
             if drain {
                 let rx = {
                     let mut guard = rx_arc.lock().await;
@@ -2144,8 +2177,8 @@ impl PySubscription {
                 };
                 if let Some(mut rx) = rx {
                     while let Ok(item) = rx.try_recv() {
-                        if let Ok(batch) = item {
-                            remaining.push(batch);
+                        if let Ok(update) = item {
+                            remaining.push(update);
                         }
                     }
                 }
@@ -2170,8 +2203,8 @@ impl PySubscription {
             if !remaining.is_empty() {
                 try_attach_or_suspend(|py| {
                     let list = pyo3::types::PyList::empty(py);
-                    for batch in remaining {
-                        let py_batch = record_batch_to_pyarrow(py, batch)?;
+                    for update in remaining {
+                        let py_batch = subscription_update_to_pyarrow(py, update)?;
                         list.append(py_batch)?;
                     }
                     Ok(list.into_any().unbind())
@@ -2403,6 +2436,94 @@ fn market_info_to_pydict(py: Python<'_>, info: &MarketInfo) -> PyResult<Py<PyAny
     dict.set_item("tz", info.tz.clone())?;
     dict.set_item("freq", info.freq.clone())?;
     dict.set_item("is_fut", info.is_fut)?;
+    Ok(dict.into_any().unbind())
+}
+
+fn subscription_update_to_pyarrow(
+    py: Python<'_>,
+    update: SubscriptionUpdate,
+) -> PyResult<Py<PyAny>> {
+    let batch = subscription_update_to_record_batch(&update).map_err(blp_error_to_pyerr)?;
+    record_batch_to_pyarrow(py, batch)
+}
+
+fn date32_to_py(py: Python<'_>, days: i32) -> PyResult<Py<PyAny>> {
+    let Some(epoch) = NaiveDate::from_ymd_opt(1970, 1, 1) else {
+        return Ok(py.None());
+    };
+    let Some(date) = epoch.checked_add_signed(chrono::Duration::days(days as i64)) else {
+        return Ok(py.None());
+    };
+    Ok(
+        PyDate::new(py, date.year(), date.month() as u8, date.day() as u8)?
+            .into_any()
+            .unbind(),
+    )
+}
+
+fn time64_micros_to_py(py: Python<'_>, micros: i64) -> PyResult<Py<PyAny>> {
+    if !(0..86_400_000_000).contains(&micros) {
+        return Ok(py.None());
+    }
+    let seconds = micros / 1_000_000;
+    let microsecond = (micros % 1_000_000) as u32;
+    let hour = (seconds / 3_600) as u8;
+    let minute = ((seconds % 3_600) / 60) as u8;
+    let second = (seconds % 60) as u8;
+    Ok(PyTime::new(py, hour, minute, second, microsecond, None)?
+        .into_any()
+        .unbind())
+}
+
+fn timestamp_micros_to_py(py: Python<'_>, micros: i64) -> PyResult<Py<PyAny>> {
+    let Some(dt) = DateTime::from_timestamp_micros(micros) else {
+        return Ok(py.None());
+    };
+    Ok(PyDateTime::new(
+        py,
+        dt.year(),
+        dt.month() as u8,
+        dt.day() as u8,
+        dt.hour() as u8,
+        dt.minute() as u8,
+        dt.second() as u8,
+        dt.timestamp_subsec_micros(),
+        None,
+    )?
+    .into_any()
+    .unbind())
+}
+
+fn subscription_update_to_pydict(
+    py: Python<'_>,
+    update: SubscriptionUpdate,
+) -> PyResult<Py<PyAny>> {
+    let dict = PyDict::new(py);
+    dict.set_item(
+        "timestamp",
+        timestamp_micros_to_py(py, update.timestamp_us)?,
+    )?;
+    dict.set_item("topic", update.topic.as_ref())?;
+    for field in update.values.iter() {
+        let Some(meta) = update.layout.fields.get(field.index as usize) else {
+            continue;
+        };
+        match &field.value {
+            UpdateValue::Null => dict.set_item(meta.name.as_ref(), py.None())?,
+            UpdateValue::Bool(v) => dict.set_item(meta.name.as_ref(), *v)?,
+            UpdateValue::I32(v) => dict.set_item(meta.name.as_ref(), *v)?,
+            UpdateValue::I64(v) => dict.set_item(meta.name.as_ref(), *v)?,
+            UpdateValue::F64(v) => dict.set_item(meta.name.as_ref(), *v)?,
+            UpdateValue::Str(v) => dict.set_item(meta.name.as_ref(), v.as_ref())?,
+            UpdateValue::Date32(v) => dict.set_item(meta.name.as_ref(), date32_to_py(py, *v)?)?,
+            UpdateValue::Time64Micros(v) => {
+                dict.set_item(meta.name.as_ref(), time64_micros_to_py(py, *v)?)?
+            }
+            UpdateValue::TimestampMicros(v) => {
+                dict.set_item(meta.name.as_ref(), timestamp_micros_to_py(py, *v)?)?
+            }
+        }
+    }
     Ok(dict.into_any().unbind())
 }
 

--- a/crates/xbbg-async/src/engine/mod.rs
+++ b/crates/xbbg-async/src/engine/mod.rs
@@ -45,7 +45,7 @@ pub use request_pool::RequestWorkerPool;
 use state::SubscriptionMetrics;
 pub use state::{
     BqlState, BulkDataState, HistDataState, IntradayTickState, LongMode, OutputFormat,
-    RefDataState, SubscriptionState,
+    RefDataState, SubscriptionState, SubscriptionUpdate,
 };
 pub use subscription_pool::{SessionClaim, SubscriptionCommandHandle, SubscriptionSessionPool};
 pub use worker::{UnifiedRequestState, WorkerCommand, WorkerHandle};
@@ -1995,16 +1995,16 @@ impl Drop for Engine {
 /// Provides async iteration over incoming data and methods to dynamically
 /// add/remove tickers while the subscription is active.
 ///
-/// Data arrives as `Result<RecordBatch, BlpError>`:
-/// - `Ok(batch)` — normal data
+/// Data arrives as `Result<SubscriptionUpdate, BlpError>`:
+/// - `Ok(update)` — normal data
 /// - `Err(error)` — subscription failure, session death, etc.
 ///
 /// The underlying session is released back to the pool on drop.
 pub struct SubscriptionStream {
     /// Receiver for incoming data batches (or errors).
-    rx: mpsc::Receiver<Result<RecordBatch, BlpError>>,
+    rx: mpsc::Receiver<Result<SubscriptionUpdate, BlpError>>,
     /// Sender for adding new topics (shares channel with existing subs).
-    tx: mpsc::Sender<Result<RecordBatch, BlpError>>,
+    tx: mpsc::Sender<Result<SubscriptionUpdate, BlpError>>,
     /// Session claim (released on drop).
     claim: Option<SessionClaim>,
     /// Subscribed fields.
@@ -2047,15 +2047,15 @@ impl SubscriptionStream {
     /// Receive the next batch of data or an error.
     ///
     /// Returns:
-    /// - `Some(Ok(batch))` — normal data
+    /// - `Some(Ok(update))` — normal data
     /// - `Some(Err(error))` — subscription failure, session death, etc.
     /// - `None` — subscription is closed
-    pub async fn next(&mut self) -> Option<Result<RecordBatch, BlpError>> {
+    pub async fn next(&mut self) -> Option<Result<SubscriptionUpdate, BlpError>> {
         self.rx.recv().await
     }
 
     /// Try to receive data without blocking.
-    pub fn try_next(&mut self) -> Option<Result<RecordBatch, BlpError>> {
+    pub fn try_next(&mut self) -> Option<Result<SubscriptionUpdate, BlpError>> {
         self.rx.try_recv().ok()
     }
 
@@ -2158,9 +2158,12 @@ impl SubscriptionStream {
 
     /// Unsubscribe from all topics and close the stream.
     ///
-    /// If `drain` is true, returns remaining buffered batches before closing.
-    /// Errors in the drain are silently discarded — only successful batches are returned.
-    pub async fn unsubscribe(mut self, drain: bool) -> Result<Vec<RecordBatch>, BlpAsyncError> {
+    /// If `drain` is true, returns remaining buffered updates before closing.
+    /// Errors in the drain are silently discarded — only successful updates are returned.
+    pub async fn unsubscribe(
+        mut self,
+        drain: bool,
+    ) -> Result<Vec<SubscriptionUpdate>, BlpAsyncError> {
         let mut remaining = Vec::new();
 
         if drain {
@@ -2207,8 +2210,8 @@ impl SubscriptionStream {
         self,
     ) -> Result<
         (
-            mpsc::Receiver<Result<RecordBatch, BlpError>>,
-            mpsc::Sender<Result<RecordBatch, BlpError>>,
+            mpsc::Receiver<Result<SubscriptionUpdate, BlpError>>,
+            mpsc::Sender<Result<SubscriptionUpdate, BlpError>>,
             SessionClaim,
             SharedSubscriptionStatus,
             Option<usize>,          // flush_threshold

--- a/crates/xbbg-async/src/engine/state/mod.rs
+++ b/crates/xbbg-async/src/engine/state/mod.rs
@@ -14,6 +14,8 @@ mod intradaytick_stream;
 mod refdata;
 mod subscription;
 pub mod typed_builder;
+mod update;
+mod update_arrow;
 mod value_utils;
 
 pub use bql::BqlState;
@@ -29,3 +31,8 @@ pub use intradaytick::IntradayTickState;
 pub use intradaytick_stream::IntradayTickStreamState;
 pub use refdata::{LongMode, OutputFormat, RefDataState};
 pub use subscription::{SubscriptionMetrics, SubscriptionState};
+pub use update::{
+    FieldIndex, FieldKind, FieldLayout, FieldMeta, SubscriptionUpdate, TopicId, UpdateField,
+    UpdateValue,
+};
+pub use update_arrow::subscription_update_to_record_batch;

--- a/crates/xbbg-async/src/engine/state/subscription.rs
+++ b/crates/xbbg-async/src/engine/state/subscription.rs
@@ -1,22 +1,22 @@
-//! Subscription state with Arrow builders for real-time data.
+//! Update-first subscription state for real-time data.
 //!
-//! Extracts subscription messages directly from Bloomberg Elements
-//! without JSON intermediate serialization. Uses dynamic type dispatch
-//! to preserve all Bloomberg types (string, int, float, datetime, etc.).
+//! Extracts Bloomberg subscription messages into native `SubscriptionUpdate`s
+//! without constructing Arrow on the hot path. Arrow conversion is an explicit
+//! compatibility adapter in `update_arrow`.
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 
-use arrow::array::{ArrayRef, StringBuilder, TimestampMicrosecondBuilder};
-use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
-use arrow::record_batch::RecordBatch;
 use tokio::sync::mpsc;
 
-use xbbg_core::{BlpError, DataType as BlpDataType, Message, Name, Value};
+use xbbg_core::{BlpError, DataType as BlpDataType, Message, Name};
 
 use super::super::OverflowPolicy;
-use super::typed_builder::{ArrowType, TypedBuilder};
+use super::update::{
+    FieldIndex, FieldKind, FieldLayout, FieldMeta, SubscriptionUpdate, TopicId, UpdateField,
+    UpdateValue,
+};
 
 pub struct SubscriptionMetrics {
     pub messages_received: Arc<AtomicU64>,
@@ -32,7 +32,7 @@ pub struct SubscriptionMetrics {
 enum AllFieldSlot {
     Captured {
         key: usize,
-        idx: usize,
+        idx: FieldIndex,
         datatype: BlpDataType,
     },
     Skipped {
@@ -44,47 +44,37 @@ enum AllFieldSlot {
 pub struct SubscriptionState {
     /// Topic string (e.g., "IBM US Equity")
     pub topic: Arc<str>,
-    /// Field names as strings for schema, logs, and user-visible column names.
-    pub field_strings: Vec<String>,
+    topic_id: TopicId,
+    /// Field names as strings for layout, logs, and compatibility schemas.
+    pub field_strings: Vec<Arc<str>>,
     /// Pre-interned field names for requested-field hot-path lookup.
     field_names: Vec<Name>,
     /// Fast dynamic-field lookup keyed by Bloomberg's interned Name pointer.
-    field_name_keys: HashMap<usize, usize>,
+    field_name_keys: HashMap<usize, FieldIndex>,
     /// Per-field flag for Bloomberg date-or-time fields that cannot be read safely.
     invalid_dateortime_fields: Vec<bool>,
     /// Per-position allFields cache for stable Bloomberg subscription schemas.
     all_field_slots: Vec<Option<AllFieldSlot>>,
-    /// Timestamp builder (event time)
-    pub timestamp_builder: TimestampMicrosecondBuilder,
-    /// Topic builder (repeated for each row)
-    pub topic_builder: StringBuilder,
-    /// Field value builders — None until type is inferred from first non-null value.
-    /// This preserves Bloomberg's native types (Int32, Int64, Float64, String, Date, etc.)
-    /// instead of forcing everything through Float64.
-    pub field_builders: Vec<Option<TypedBuilder>>,
-    /// Stream to send RecordBatches (or errors for subscription failures)
-    pub stream: mpsc::Sender<Result<RecordBatch, BlpError>>,
-    /// Number of pending rows before flush
-    pub pending_count: usize,
-    /// Flush threshold
+    field_kinds: Vec<FieldKind>,
+    layout_version: u32,
+    layout: Arc<FieldLayout>,
+    /// Stream to send native updates (or errors for subscription failures).
+    pub stream: mpsc::Sender<Result<SubscriptionUpdate, BlpError>>,
+    /// Retained for option/status compatibility. Updates are emitted immediately.
     pub flush_threshold: usize,
     /// Slow consumer flag (DATALOSS received)
     pub slow_consumer: bool,
     /// Overflow policy for slow consumers
     pub overflow_policy: OverflowPolicy,
-    /// Dropped batch count (for metrics)
+    /// Dropped update count (keeps historical field name for stats compatibility)
     pub dropped_batches: u64,
     pub metrics: Arc<SubscriptionMetrics>,
-    /// Cached schema — invalidated when a field type is first inferred.
-    cached_schema: Option<Arc<Schema>>,
     /// Whether at least one data message has been observed.
     has_received_data: bool,
     /// Suppress stream-closed warnings during expected shutdown paths.
     suppress_closed_warning: bool,
     /// Whether to append all top-level scalar fields Bloomberg exposes.
     capture_all_fields: bool,
-    /// Logs the first post-lock conversion miss per field without changing payload semantics.
-    conversion_miss_logged: Vec<bool>,
 }
 
 impl SubscriptionState {
@@ -98,7 +88,7 @@ impl SubscriptionState {
     pub fn new(
         topic: String,
         fields: Vec<String>,
-        stream: mpsc::Sender<Result<RecordBatch, BlpError>>,
+        stream: mpsc::Sender<Result<SubscriptionUpdate, BlpError>>,
         flush_threshold: usize,
         capture_all_fields: bool,
     ) -> Self {
@@ -116,7 +106,7 @@ impl SubscriptionState {
     pub fn with_policy(
         topic: String,
         fields: Vec<String>,
-        stream: mpsc::Sender<Result<RecordBatch, BlpError>>,
+        stream: mpsc::Sender<Result<SubscriptionUpdate, BlpError>>,
         flush_threshold: usize,
         overflow_policy: OverflowPolicy,
         capture_all_fields: bool,
@@ -128,30 +118,29 @@ impl SubscriptionState {
             HashMap::with_capacity(fields.len() + Self::EVENT_METADATA_FIELDS.len());
         let mut invalid_dateortime_fields =
             Vec::with_capacity(fields.len() + Self::EVENT_METADATA_FIELDS.len());
+        let mut field_kinds = Vec::with_capacity(fields.len() + Self::EVENT_METADATA_FIELDS.len());
+
         for field in fields {
-            let name = Name::get_or_intern(&field);
-            let key = name.as_ptr() as usize;
-            if let std::collections::hash_map::Entry::Vacant(entry) = field_name_keys.entry(key) {
-                let idx = field_strings.len();
-                entry.insert(idx);
-                invalid_dateortime_fields.push(Self::is_invalid_dateortime_field(&field));
-                field_names.push(name);
-                field_strings.push(field);
-            }
+            Self::push_field_if_new(
+                &mut field_strings,
+                &mut field_names,
+                &mut field_name_keys,
+                &mut invalid_dateortime_fields,
+                &mut field_kinds,
+                field.into(),
+            );
         }
         for field in Self::EVENT_METADATA_FIELDS {
-            let name = Name::get_or_intern(field);
-            let key = name.as_ptr() as usize;
-            if let std::collections::hash_map::Entry::Vacant(entry) = field_name_keys.entry(key) {
-                let idx = field_strings.len();
-                entry.insert(idx);
-                invalid_dateortime_fields.push(Self::is_invalid_dateortime_field(field));
-                field_strings.push(field.to_string());
-                field_names.push(name);
-            }
+            Self::push_field_if_new(
+                &mut field_strings,
+                &mut field_names,
+                &mut field_name_keys,
+                &mut invalid_dateortime_fields,
+                &mut field_kinds,
+                Arc::from(field),
+            );
         }
-        let field_builders = field_strings.iter().map(|_| None).collect();
-        let field_count = field_strings.len();
+
         let metrics = Arc::new(SubscriptionMetrics {
             messages_received: Arc::new(AtomicU64::new(0)),
             dropped_batches: Arc::new(AtomicU64::new(0)),
@@ -161,62 +150,83 @@ impl SubscriptionState {
             last_message_us: Arc::new(AtomicU64::new(0)),
             last_data_loss_us: Arc::new(AtomicU64::new(0)),
         });
+        let layout = Self::build_layout(1, &field_strings, &field_kinds);
 
         Self {
-            topic: topic.into(),
+            topic: Arc::from(topic),
+            topic_id: 0,
             field_strings,
             field_names,
             field_name_keys,
             invalid_dateortime_fields,
             all_field_slots: Vec::new(),
-            timestamp_builder: TimestampMicrosecondBuilder::new(),
-            topic_builder: StringBuilder::new(),
-            field_builders,
+            field_kinds,
+            layout_version: 1,
+            layout,
             stream,
-            pending_count: 0,
             flush_threshold,
             slow_consumer: false,
             overflow_policy,
             dropped_batches: 0,
             metrics,
-            cached_schema: None,
             has_received_data: false,
             suppress_closed_warning: false,
             capture_all_fields,
-            conversion_miss_logged: vec![false; field_count],
         }
     }
 
+    pub fn set_topic_id(&mut self, topic_id: TopicId) {
+        self.topic_id = topic_id;
+    }
+
+    fn push_field_if_new(
+        field_strings: &mut Vec<Arc<str>>,
+        field_names: &mut Vec<Name>,
+        field_name_keys: &mut HashMap<usize, FieldIndex>,
+        invalid_dateortime_fields: &mut Vec<bool>,
+        field_kinds: &mut Vec<FieldKind>,
+        field: Arc<str>,
+    ) -> FieldIndex {
+        let name = Name::get_or_intern(&field);
+        let key = name.as_ptr() as usize;
+        if let Some(&idx) = field_name_keys.get(&key) {
+            return idx;
+        }
+        let idx = field_strings.len() as FieldIndex;
+        field_name_keys.insert(key, idx);
+        invalid_dateortime_fields.push(Self::is_invalid_dateortime_field(&field));
+        field_kinds.push(FieldKind::Unknown);
+        field_names.push(name);
+        field_strings.push(field);
+        idx
+    }
+
+    fn build_layout(version: u32, names: &[Arc<str>], kinds: &[FieldKind]) -> Arc<FieldLayout> {
+        Arc::new(FieldLayout::new(
+            version,
+            names
+                .iter()
+                .zip(kinds.iter())
+                .enumerate()
+                .map(|(idx, (name, kind))| FieldMeta::new(name.clone(), idx as FieldIndex, *kind))
+                .collect(),
+        ))
+    }
+
     /// Process a SUBSCRIPTION_DATA message using Element API.
-    ///
-    /// Uses dynamic type dispatch (`get_value`) to preserve Bloomberg's native types.
-    /// Field types are inferred on first non-null value and locked in for the
-    /// lifetime of the subscription. String, Date, Datetime, Bool, Int, Float
-    /// are all preserved — no more Float64-only extraction.
     ///
     /// Timestamps use Bloomberg SDK receive time when available (requires
     /// `setRecordSubscriptionDataReceiveTimes(true)`), falling back to
     /// `SystemTime::now()` if not enabled.
     pub fn on_message(&mut self, msg: &Message) -> bool {
-        // Use Bloomberg SDK receive time if available, fallback to system time
-        let timestamp = msg.time_received_us().unwrap_or_else(|| {
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_micros() as i64)
-                .unwrap_or(0)
-        });
-
-        self.timestamp_builder.append_value(timestamp);
-        self.topic_builder.append_value(self.topic.as_ref());
-
+        let timestamp = msg.time_received_us().unwrap_or_else(Self::system_time_us);
         let elem = msg.elements();
-        if self.capture_all_fields {
-            self.append_all_fields(&elem);
+        let values = if self.capture_all_fields {
+            self.extract_all_fields(&elem)
         } else {
-            self.append_requested_fields(&elem);
-        }
+            self.extract_requested_fields(&elem)
+        };
 
-        self.pending_count += 1;
         self.metrics
             .messages_received
             .fetch_add(1, Ordering::Relaxed);
@@ -227,26 +237,46 @@ impl SubscriptionState {
         let first_message = !self.has_received_data;
         self.has_received_data = true;
 
-        // Auto-flush if threshold reached
-        if self.pending_count >= self.flush_threshold {
-            self.flush();
-        }
+        let update = SubscriptionUpdate {
+            timestamp_us: timestamp,
+            topic_id: self.topic_id,
+            topic: self.topic.clone(),
+            layout: self.layout.clone(),
+            values: values.into_boxed_slice(),
+        };
+        self.send_update(update);
 
         first_message
     }
 
-    fn append_requested_fields(&mut self, elem: &xbbg_core::Element<'_>) {
-        for idx in 0..self.field_strings.len() {
-            let invalid_dateortime = self.invalid_dateortime_fields[idx];
-            if let Some(field_elem) = elem.get(&self.field_names[idx]) {
-                self.append_field_value_at(idx, invalid_dateortime, &field_elem);
-            } else {
-                self.append_missing_at(idx);
-            }
-        }
+    fn system_time_us() -> i64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_micros() as i64)
+            .unwrap_or(0)
     }
 
-    fn append_all_fields(&mut self, elem: &xbbg_core::Element<'_>) {
+    fn extract_requested_fields(&mut self, elem: &xbbg_core::Element<'_>) -> Vec<UpdateField> {
+        let mut values = Vec::with_capacity(self.field_names.len());
+        for idx in 0..self.field_names.len() {
+            let value = if self.invalid_dateortime_fields[idx] {
+                UpdateValue::Null
+            } else {
+                elem.get(&self.field_names[idx])
+                    .map(|field| UpdateValue::from_blp(field.get_value_fast(0)))
+                    .unwrap_or(UpdateValue::Null)
+            };
+            self.observe_kind(idx as FieldIndex, &value);
+            values.push(UpdateField {
+                index: idx as FieldIndex,
+                value,
+            });
+        }
+        values
+    }
+
+    fn extract_all_fields(&mut self, elem: &xbbg_core::Element<'_>) -> Vec<UpdateField> {
+        let mut values = Vec::with_capacity(elem.num_children());
         for child_idx in 0..elem.num_children() {
             let Some(child) = elem.get_at(child_idx) else {
                 continue;
@@ -260,12 +290,9 @@ impl SubscriptionState {
                         idx,
                         datatype,
                     } if cached_key == key => {
-                        self.append_field_value_with_datatype_at(
-                            idx,
-                            self.invalid_dateortime_fields[idx],
-                            &child,
-                            datatype,
-                        );
+                        let value = self.extract_child_value(idx, &child, datatype);
+                        self.observe_kind(idx, &value);
+                        values.push(UpdateField { index: idx, value });
                         continue;
                     }
                     AllFieldSlot::Skipped { key: cached_key } if cached_key == key => continue,
@@ -281,12 +308,35 @@ impl SubscriptionState {
 
             let idx = self.ensure_field_for_child(&child, key);
             self.cache_all_field_slot(child_idx, AllFieldSlot::Captured { key, idx, datatype });
-            self.append_field_value_with_datatype_at(
-                idx,
-                self.invalid_dateortime_fields[idx],
-                &child,
-                datatype,
-            );
+            let value = self.extract_child_value(idx, &child, datatype);
+            self.observe_kind(idx, &value);
+            values.push(UpdateField { index: idx, value });
+        }
+        values
+    }
+
+    fn extract_child_value(
+        &self,
+        idx: FieldIndex,
+        child: &xbbg_core::Element<'_>,
+        datatype: BlpDataType,
+    ) -> UpdateValue {
+        if self.invalid_dateortime_fields[idx as usize] {
+            UpdateValue::Null
+        } else {
+            UpdateValue::from_blp(child.get_value_fast_with_datatype(0, datatype))
+        }
+    }
+
+    fn observe_kind(&mut self, idx: FieldIndex, value: &UpdateValue) {
+        let idx = idx as usize;
+        let observed = FieldKind::from_value(value);
+        let merged = self.field_kinds[idx].merge_observed(observed);
+        if merged != self.field_kinds[idx] {
+            self.field_kinds[idx] = merged;
+            self.layout_version = self.layout_version.wrapping_add(1).max(1);
+            self.layout =
+                Self::build_layout(self.layout_version, &self.field_strings, &self.field_kinds);
         }
     }
 
@@ -311,100 +361,28 @@ impl SubscriptionState {
         &mut self,
         field: &xbbg_core::Element<'_>,
         field_key: usize,
-    ) -> usize {
+    ) -> FieldIndex {
         if let Some(&idx) = self.field_name_keys.get(&field_key) {
             return idx;
         }
 
-        let field_name = field.name_str();
-        let idx = self.field_strings.len();
-        let name = Name::get_or_intern(field_name);
-        self.field_strings.push(field_name.to_string());
-        self.field_builders.push(None);
+        let field_name = Arc::<str>::from(field.name_str());
+        let idx = self.field_strings.len() as FieldIndex;
+        let name = Name::get_or_intern(&field_name);
+        self.field_strings.push(field_name.clone());
         self.field_names.push(name);
         self.field_name_keys.insert(field_key, idx);
         self.invalid_dateortime_fields
-            .push(Self::is_invalid_dateortime_field(field_name));
-        self.conversion_miss_logged.push(false);
-        self.cached_schema = None;
+            .push(Self::is_invalid_dateortime_field(&field_name));
+        self.field_kinds.push(FieldKind::Unknown);
+        self.layout_version = self.layout_version.wrapping_add(1).max(1);
+        self.layout =
+            Self::build_layout(self.layout_version, &self.field_strings, &self.field_kinds);
         idx
     }
 
     fn is_invalid_dateortime_field(field_name: &str) -> bool {
         Self::INVALID_DATEORTIME_FIELDS.contains(&field_name)
-    }
-
-    fn append_field_value_at(
-        &mut self,
-        idx: usize,
-        invalid_dateortime: bool,
-        field: &xbbg_core::Element<'_>,
-    ) {
-        if invalid_dateortime {
-            self.append_invalid_dateortime_fallback_at(idx);
-        } else {
-            self.append_value_at(idx, field.get_value_fast(0));
-        }
-    }
-
-    fn append_field_value_with_datatype_at(
-        &mut self,
-        idx: usize,
-        invalid_dateortime: bool,
-        field: &xbbg_core::Element<'_>,
-        datatype: BlpDataType,
-    ) {
-        if invalid_dateortime {
-            self.append_invalid_dateortime_fallback_at(idx);
-        } else {
-            self.append_value_at(idx, field.get_value_fast_with_datatype(0, datatype));
-        }
-    }
-
-    fn append_value_at(&mut self, idx: usize, value: Option<Value<'_>>) {
-        if value.as_ref().is_none_or(|v| matches!(v, Value::Null)) {
-            return;
-        }
-
-        if let Some(builder) = &mut self.field_builders[idx] {
-            let incoming_type = value.as_ref().map(ArrowType::from_value);
-            Self::pad_builder_to_len(builder, self.pending_count);
-            let locked_type = builder.arrow_type();
-            let missed = builder.append_value_report_miss(value);
-            if missed && !self.conversion_miss_logged[idx] {
-                self.conversion_miss_logged[idx] = true;
-                xbbg_log::warn!(
-                    topic = %self.topic,
-                    field = %self.field_strings[idx],
-                    locked_type = locked_type.type_name(),
-                    incoming_type = incoming_type.map(|t| t.type_name()).unwrap_or("unknown"),
-                    "subscription field value could not be converted to locked Arrow type; appending null"
-                );
-            }
-            return;
-        }
-
-        let v = value.as_ref().expect("non-null value checked above");
-        let arrow_type = ArrowType::from_value(v);
-        let mut builder = TypedBuilder::new(arrow_type);
-        Self::pad_builder_to_len(&mut builder, self.pending_count);
-        builder.append_value(value);
-        self.field_builders[idx] = Some(builder);
-        self.cached_schema = None;
-    }
-
-    fn pad_builder_to_len(builder: &mut TypedBuilder, len: usize) {
-        while builder.len() < len {
-            builder.append_null();
-        }
-    }
-
-    fn append_invalid_dateortime_fallback_at(&mut self, idx: usize) {
-        self.append_missing_at(idx);
-    }
-
-    fn append_missing_at(&mut self, _idx: usize) {
-        // Missing values are padded lazily before the next present value and at flush.
     }
 
     /// Handle DATALOSS indicator.
@@ -430,112 +408,19 @@ impl SubscriptionState {
         self.suppress_closed_warning = true;
     }
 
-    /// Flush pending rows as a RecordBatch.
-    pub fn flush(&mut self) {
-        let Some(batch) = self.finish_pending_batch() else {
-            return;
-        };
-
-        self.send_batch(batch);
-    }
-
-    fn finish_pending_batch(&mut self) -> Option<RecordBatch> {
-        if self.pending_count == 0 {
-            return None;
-        }
-
-        // Build fixed arrays
-        let timestamp_array = self.timestamp_builder.finish().with_timezone("UTC");
-        let topic_array = self.topic_builder.finish();
-
-        // Build field arrays — use TypedBuilder where available, String nulls otherwise
-        let pending_count = self.pending_count;
-        let field_arrays: Vec<ArrayRef> = self
-            .field_builders
-            .iter_mut()
-            .map(|builder_opt| {
-                if let Some(builder) = builder_opt {
-                    Self::pad_builder_to_len(builder, pending_count);
-                    builder.finish()
-                } else {
-                    // Field was never non-null in this batch — produce Utf8 column of all nulls
-                    let mut sb = StringBuilder::new();
-                    for _ in 0..self.pending_count {
-                        sb.append_null();
-                    }
-                    Arc::new(sb.finish()) as ArrayRef
-                }
-            })
-            .collect();
-
-        // Get or build schema (cached after first build)
-        let schema = self.get_or_build_schema();
-
-        // Build columns
-        let mut columns: Vec<Arc<dyn arrow::array::Array>> =
-            vec![Arc::new(timestamp_array), Arc::new(topic_array)];
-        columns.extend(field_arrays);
-
-        let batch = match RecordBatch::try_new(schema, columns) {
-            Ok(batch) => Some(batch),
-            Err(e) => {
-                xbbg_log::error!(topic = %self.topic, error = %e, "failed to create RecordBatch");
-                None
-            }
-        };
-
-        self.pending_count = 0;
-        batch
-    }
-
-    /// Get or build the Arrow schema, caching it for reuse.
-    ///
-    /// The schema is invalidated whenever a new field type is inferred
-    /// (when a previously-null field gets its first non-null value).
-    fn get_or_build_schema(&mut self) -> Arc<Schema> {
-        if let Some(ref schema) = self.cached_schema {
-            return schema.clone();
-        }
-
-        let mut fields = vec![
-            Field::new(
-                "timestamp",
-                DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
-                false,
-            ),
-            Field::new("topic", DataType::Utf8, false),
-        ];
-
-        for (i, name) in self.field_strings.iter().enumerate() {
-            let dt = self.field_builders[i]
-                .as_ref()
-                .map(|b| b.data_type())
-                .unwrap_or(DataType::Utf8); // Unknown fields default to string
-            fields.push(Field::new(name.as_str(), dt, true));
-        }
-
-        let schema = Arc::new(Schema::new(fields));
-        self.cached_schema = Some(schema.clone());
-        schema
-    }
+    /// Native updates are emitted immediately. This remains for existing worker
+    /// shutdown/drop callsites that previously flushed Arrow builders.
+    pub fn flush(&mut self) {}
 
     /// Send an error to the consumer.
-    ///
-    /// Used for subscription failures, session termination, etc.
-    /// Uses try_send to avoid blocking the worker thread.
     pub fn fail(&self, error: BlpError) {
         let _ = self.stream.try_send(Err(error));
     }
 
-    /// Send a batch according to the configured overflow policy.
-    ///
-    /// `Block` uses `blocking_send` to apply backpressure.
-    fn send_batch(&mut self, batch: RecordBatch) {
+    fn send_update(&mut self, update: SubscriptionUpdate) {
         match self.overflow_policy {
             OverflowPolicy::Block => {
-                // blocking_send is designed for sync contexts (subscription worker thread).
-                // Blocks until space is available or the receiver is dropped.
-                if self.stream.blocking_send(Ok(batch)).is_err() {
+                if self.stream.blocking_send(Ok(update)).is_err() {
                     if !self.suppress_closed_warning {
                         xbbg_log::warn!(topic = %self.topic, "stream closed");
                     }
@@ -543,54 +428,27 @@ impl SubscriptionState {
                     self.metrics.batches_sent.fetch_add(1, Ordering::Relaxed);
                 }
             }
-            OverflowPolicy::DropNewest => {
-                // try_send: drop newest batch when buffer is full
-                match self.stream.try_send(Ok(batch)) {
-                    Ok(()) => {
-                        self.metrics.batches_sent.fetch_add(1, Ordering::Relaxed);
-                    }
-                    Err(mpsc::error::TrySendError::Full(_)) => {
-                        self.dropped_batches += 1;
-                        self.metrics.dropped_batches.fetch_add(1, Ordering::Relaxed);
-                        let policy_label = "DropNewest";
-                        xbbg_log::warn!(
-                            topic = %self.topic,
-                            dropped = self.dropped_batches,
-                            policy = policy_label,
-                            "stream full - dropping batch"
-                        );
-                    }
-                    Err(mpsc::error::TrySendError::Closed(_)) => {
-                        if !self.suppress_closed_warning {
-                            xbbg_log::warn!(topic = %self.topic, "stream closed");
-                        }
+            OverflowPolicy::DropNewest => match self.stream.try_send(Ok(update)) {
+                Ok(()) => {
+                    self.metrics.batches_sent.fetch_add(1, Ordering::Relaxed);
+                }
+                Err(mpsc::error::TrySendError::Full(_)) => {
+                    self.dropped_batches += 1;
+                    self.metrics.dropped_batches.fetch_add(1, Ordering::Relaxed);
+                    xbbg_log::warn!(
+                        topic = %self.topic,
+                        dropped = self.dropped_batches,
+                        policy = "DropNewest",
+                        "stream full - dropping update"
+                    );
+                }
+                Err(mpsc::error::TrySendError::Closed(_)) => {
+                    if !self.suppress_closed_warning {
+                        xbbg_log::warn!(topic = %self.topic, "stream closed");
                     }
                 }
-            }
+            },
         }
-    }
-
-    fn send_batch_best_effort(&mut self, batch: RecordBatch) {
-        match self.stream.try_send(Ok(batch)) {
-            Ok(()) => {
-                self.metrics.batches_sent.fetch_add(1, Ordering::Relaxed);
-            }
-            Err(mpsc::error::TrySendError::Full(_)) => {
-                self.dropped_batches += 1;
-                self.metrics.dropped_batches.fetch_add(1, Ordering::Relaxed);
-            }
-            Err(mpsc::error::TrySendError::Closed(_)) => {}
-        }
-    }
-}
-
-impl Drop for SubscriptionState {
-    fn drop(&mut self) {
-        let Some(batch) = self.finish_pending_batch() else {
-            return;
-        };
-
-        self.send_batch_best_effort(batch);
     }
 }
 
@@ -610,7 +468,11 @@ mod tests {
         );
 
         assert_eq!(
-            state.field_strings,
+            state
+                .field_strings
+                .iter()
+                .map(|s| s.to_string())
+                .collect::<Vec<_>>(),
             vec![
                 "LAST_PRICE".to_string(),
                 "MKTDATA_EVENT_TYPE".to_string(),
@@ -618,17 +480,26 @@ mod tests {
             ]
         );
         assert_eq!(state.field_names.len(), state.field_strings.len());
-        assert_eq!(state.field_builders.len(), state.field_strings.len());
         assert_eq!(
             state.invalid_dateortime_fields.len(),
             state.field_strings.len()
         );
-        assert_eq!(
-            state.conversion_miss_logged.len(),
-            state.field_strings.len()
-        );
         for (field, name) in state.field_strings.iter().zip(state.field_names.iter()) {
-            assert_eq!(name.as_str(), field);
+            assert_eq!(name.as_str(), field.as_ref());
         }
+    }
+
+    #[test]
+    fn invalid_dateortime_guard_is_preserved_in_layout() {
+        let (tx, _rx) = mpsc::channel(1);
+        let state = SubscriptionState::new(
+            "AAPL US Equity".to_string(),
+            vec!["LAST_UPDATE_ALL_SESSIONS_RT".to_string()],
+            tx,
+            1,
+            false,
+        );
+
+        assert!(state.invalid_dateortime_fields[0]);
     }
 }

--- a/crates/xbbg-async/src/engine/state/update.rs
+++ b/crates/xbbg-async/src/engine/state/update.rs
@@ -1,0 +1,138 @@
+use std::sync::Arc;
+
+use xbbg_core::Value;
+
+pub type FieldIndex = u16;
+pub type TopicId = u32;
+
+#[derive(Clone, Debug)]
+pub struct FieldLayout {
+    pub version: u32,
+    pub fields: Arc<[FieldMeta]>,
+}
+
+#[derive(Clone, Debug)]
+pub struct FieldMeta {
+    pub name: Arc<str>,
+    pub index: FieldIndex,
+    pub kind: FieldKind,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FieldKind {
+    Unknown,
+    Bool,
+    I32,
+    I64,
+    F64,
+    Str,
+    Date32,
+    Time64Micros,
+    TimestampMicros,
+}
+
+#[derive(Clone, Debug)]
+pub struct SubscriptionUpdate {
+    pub timestamp_us: i64,
+    pub topic_id: TopicId,
+    pub topic: Arc<str>,
+    pub layout: Arc<FieldLayout>,
+    pub values: Box<[UpdateField]>,
+}
+
+#[derive(Clone, Debug)]
+pub struct UpdateField {
+    pub index: FieldIndex,
+    pub value: UpdateValue,
+}
+
+#[derive(Clone, Debug)]
+pub enum UpdateValue {
+    Null,
+    Bool(bool),
+    I32(i32),
+    I64(i64),
+    F64(f64),
+    Str(Arc<str>),
+    Date32(i32),
+    Time64Micros(i64),
+    TimestampMicros(i64),
+}
+
+impl FieldLayout {
+    pub fn new(version: u32, fields: Vec<FieldMeta>) -> Self {
+        Self {
+            version,
+            fields: Arc::from(fields.into_boxed_slice()),
+        }
+    }
+}
+
+impl FieldMeta {
+    pub fn new(name: impl Into<Arc<str>>, index: FieldIndex, kind: FieldKind) -> Self {
+        Self {
+            name: name.into(),
+            index,
+            kind,
+        }
+    }
+}
+
+impl FieldKind {
+    pub fn from_value(value: &UpdateValue) -> Self {
+        match value {
+            UpdateValue::Null => Self::Unknown,
+            UpdateValue::Bool(_) => Self::Bool,
+            UpdateValue::I32(_) => Self::I32,
+            UpdateValue::I64(_) => Self::I64,
+            UpdateValue::F64(_) => Self::F64,
+            UpdateValue::Str(_) => Self::Str,
+            UpdateValue::Date32(_) => Self::Date32,
+            UpdateValue::Time64Micros(_) => Self::Time64Micros,
+            UpdateValue::TimestampMicros(_) => Self::TimestampMicros,
+        }
+    }
+
+    pub fn merge_observed(self, observed: FieldKind) -> FieldKind {
+        match (self, observed) {
+            (FieldKind::Unknown, kind) => kind,
+            (kind, FieldKind::Unknown) => kind,
+            (kind, observed) if kind == observed => kind,
+            // Preserve existing compatibility behavior: if Bloomberg changes type
+            // mid-stream, compatibility adapters expose the field as string.
+            _ => FieldKind::Str,
+        }
+    }
+}
+
+impl UpdateValue {
+    pub fn from_blp(value: Option<Value<'_>>) -> Self {
+        match value {
+            None | Some(Value::Null) => Self::Null,
+            Some(Value::Bool(v)) => Self::Bool(v),
+            Some(Value::Int32(v)) => Self::I32(v),
+            Some(Value::Int64(v)) => Self::I64(v),
+            Some(Value::Float64(v)) => Self::F64(v),
+            Some(Value::String(v)) | Some(Value::Enum(v)) => Self::Str(Arc::from(v)),
+            Some(Value::Date32(v)) => Self::Date32(v),
+            Some(Value::TimestampMicros(v)) => Self::TimestampMicros(v),
+            Some(Value::Datetime(v)) => Self::TimestampMicros(v.to_micros()),
+            Some(Value::Time64Micros(v)) => Self::Time64Micros(v),
+            Some(Value::Byte(v)) => Self::I32(v as i32),
+        }
+    }
+
+    pub fn as_string_lossy(&self) -> Option<String> {
+        match self {
+            Self::Null => None,
+            Self::Bool(v) => Some(if *v { "true" } else { "false" }.to_string()),
+            Self::I32(v) => Some(v.to_string()),
+            Self::I64(v) => Some(v.to_string()),
+            Self::F64(v) => Some(v.to_string()),
+            Self::Str(v) => Some(v.to_string()),
+            Self::Date32(v) => Some(v.to_string()),
+            Self::Time64Micros(v) => Some(v.to_string()),
+            Self::TimestampMicros(v) => Some(v.to_string()),
+        }
+    }
+}

--- a/crates/xbbg-async/src/engine/state/update_arrow.rs
+++ b/crates/xbbg-async/src/engine/state/update_arrow.rs
@@ -1,0 +1,179 @@
+use std::sync::Arc;
+
+use arrow::array::{
+    ArrayRef, BooleanBuilder, Date32Builder, Float64Builder, Int32Builder, Int64Builder,
+    StringBuilder, Time64MicrosecondBuilder, TimestampMicrosecondBuilder,
+};
+use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+use arrow::record_batch::RecordBatch;
+use xbbg_core::BlpError;
+
+use super::update::{FieldKind, SubscriptionUpdate, UpdateValue};
+
+pub fn subscription_update_to_record_batch(
+    update: &SubscriptionUpdate,
+) -> Result<RecordBatch, BlpError> {
+    let mut timestamp = TimestampMicrosecondBuilder::new();
+    timestamp.append_value(update.timestamp_us);
+
+    let mut topic = StringBuilder::new();
+    topic.append_value(update.topic.as_ref());
+
+    let mut value_by_index = vec![None; update.layout.fields.len()];
+    for field in update.values.iter() {
+        if let Some(slot) = value_by_index.get_mut(field.index as usize) {
+            *slot = Some(&field.value);
+        }
+    }
+
+    let mut fields = vec![
+        Field::new(
+            "timestamp",
+            DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+            false,
+        ),
+        Field::new("topic", DataType::Utf8, false),
+    ];
+    let mut columns: Vec<ArrayRef> = vec![
+        Arc::new(timestamp.finish().with_timezone("UTC")),
+        Arc::new(topic.finish()),
+    ];
+
+    for meta in update.layout.fields.iter() {
+        let value = value_by_index
+            .get(meta.index as usize)
+            .and_then(|value| *value);
+        let kind = match value {
+            Some(UpdateValue::Null) | None => meta.kind,
+            Some(value) => meta.kind.merge_observed(FieldKind::from_value(value)),
+        };
+        fields.push(Field::new(meta.name.as_ref(), arrow_datatype(kind), true));
+        columns.push(single_value_array(kind, value));
+    }
+
+    RecordBatch::try_new(Arc::new(Schema::new(fields)), columns).map_err(|err| BlpError::Internal {
+        detail: format!("failed to create subscription RecordBatch: {err}"),
+    })
+}
+
+fn arrow_datatype(kind: FieldKind) -> DataType {
+    match kind {
+        FieldKind::Unknown | FieldKind::Str => DataType::Utf8,
+        FieldKind::Bool => DataType::Boolean,
+        FieldKind::I32 => DataType::Int32,
+        FieldKind::I64 => DataType::Int64,
+        FieldKind::F64 => DataType::Float64,
+        FieldKind::Date32 => DataType::Date32,
+        FieldKind::Time64Micros => DataType::Time64(TimeUnit::Microsecond),
+        FieldKind::TimestampMicros => {
+            DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into()))
+        }
+    }
+}
+
+fn single_value_array(kind: FieldKind, value: Option<&UpdateValue>) -> ArrayRef {
+    match kind {
+        FieldKind::Bool => {
+            let mut b = BooleanBuilder::new();
+            match value {
+                Some(UpdateValue::Bool(v)) => b.append_value(*v),
+                _ => b.append_null(),
+            }
+            Arc::new(b.finish())
+        }
+        FieldKind::I32 => {
+            let mut b = Int32Builder::new();
+            match value {
+                Some(UpdateValue::I32(v)) => b.append_value(*v),
+                Some(UpdateValue::I64(v)) => b.append_value(*v as i32),
+                _ => b.append_null(),
+            }
+            Arc::new(b.finish())
+        }
+        FieldKind::I64 => {
+            let mut b = Int64Builder::new();
+            match value {
+                Some(UpdateValue::I64(v)) => b.append_value(*v),
+                Some(UpdateValue::I32(v)) => b.append_value(*v as i64),
+                _ => b.append_null(),
+            }
+            Arc::new(b.finish())
+        }
+        FieldKind::F64 => {
+            let mut b = Float64Builder::new();
+            match value {
+                Some(UpdateValue::F64(v)) => b.append_value(*v),
+                Some(UpdateValue::I32(v)) => b.append_value(*v as f64),
+                Some(UpdateValue::I64(v)) => b.append_value(*v as f64),
+                _ => b.append_null(),
+            }
+            Arc::new(b.finish())
+        }
+        FieldKind::Date32 => {
+            let mut b = Date32Builder::new();
+            match value {
+                Some(UpdateValue::Date32(v)) => b.append_value(*v),
+                _ => b.append_null(),
+            }
+            Arc::new(b.finish())
+        }
+        FieldKind::Time64Micros => {
+            let mut b = Time64MicrosecondBuilder::new();
+            match value {
+                Some(UpdateValue::Time64Micros(v)) => b.append_value(*v),
+                _ => b.append_null(),
+            }
+            Arc::new(b.finish())
+        }
+        FieldKind::TimestampMicros => {
+            let mut b = TimestampMicrosecondBuilder::new();
+            match value {
+                Some(UpdateValue::TimestampMicros(v)) => b.append_value(*v),
+                _ => b.append_null(),
+            }
+            Arc::new(b.finish().with_timezone("UTC"))
+        }
+        FieldKind::Unknown | FieldKind::Str => {
+            let mut b = StringBuilder::new();
+            match value.and_then(UpdateValue::as_string_lossy) {
+                Some(v) => b.append_value(&v),
+                None => b.append_null(),
+            }
+            Arc::new(b.finish())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::state::update::{FieldLayout, FieldMeta, UpdateField};
+
+    #[test]
+    fn arrow_adapter_null_fills_sparse_layout() {
+        let layout = Arc::new(FieldLayout::new(
+            2,
+            vec![
+                FieldMeta::new("BID", 0, FieldKind::F64),
+                FieldMeta::new("ASK", 1, FieldKind::F64),
+            ],
+        ));
+        let update = SubscriptionUpdate {
+            timestamp_us: 10,
+            topic_id: 1,
+            topic: Arc::from("IBM US Equity"),
+            layout,
+            values: vec![UpdateField {
+                index: 0,
+                value: UpdateValue::F64(1.25),
+            }]
+            .into_boxed_slice(),
+        };
+
+        let batch = subscription_update_to_record_batch(&update).unwrap();
+        assert_eq!(batch.num_rows(), 1);
+        assert_eq!(batch.num_columns(), 4);
+        assert_eq!(batch.schema().field(2).name(), "BID");
+        assert_eq!(batch.schema().field(3).name(), "ASK");
+    }
+}

--- a/crates/xbbg-async/src/engine/subscription_pool.rs
+++ b/crates/xbbg-async/src/engine/subscription_pool.rs
@@ -8,7 +8,6 @@ use std::sync::atomic::{AtomicU8, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 
-use arrow::record_batch::RecordBatch;
 use parking_lot::Mutex;
 use slab::Slab;
 use tokio::sync::{mpsc, oneshot};
@@ -25,7 +24,7 @@ const SERVICE_OPEN_CID_TAG: i64 = 1_i64 << 62;
 const SERVICE_OPEN_TIMEOUT_MS: u64 = 10_000;
 
 use super::dispatch::DispatchKey;
-use super::state::{SubscriptionMetrics, SubscriptionState};
+use super::state::{SubscriptionMetrics, SubscriptionState, SubscriptionUpdate};
 use super::{
     start_configured_session, BlpAsyncError, EngineConfig, OverflowPolicy, SessionLifecycleState,
     SharedSubscriptionStatus, SlabKey, SubscriptionEventLevel, SubscriptionFailureKind,
@@ -48,7 +47,7 @@ pub enum SubscriptionCommand {
         options: Vec<String>,
         flush_threshold: Option<usize>,
         overflow_policy: Option<OverflowPolicy>,
-        stream: mpsc::Sender<Result<RecordBatch, BlpError>>,
+        stream: mpsc::Sender<Result<SubscriptionUpdate, BlpError>>,
         status: SharedSubscriptionStatus,
         /// Reply with slab keys for later unsubscribe.
         reply: oneshot::Sender<SubscriptionReply>,
@@ -64,7 +63,7 @@ pub enum SubscriptionCommand {
         options: Vec<String>,
         flush_threshold: Option<usize>,
         overflow_policy: Option<OverflowPolicy>,
-        stream: mpsc::Sender<Result<RecordBatch, BlpError>>,
+        stream: mpsc::Sender<Result<SubscriptionUpdate, BlpError>>,
         status: SharedSubscriptionStatus,
         /// Reply with new slab keys.
         reply: oneshot::Sender<SubscriptionReply>,
@@ -335,7 +334,7 @@ impl SubscriptionWorker {
         options: Vec<String>,
         flush_threshold: Option<usize>,
         overflow_policy: Option<OverflowPolicy>,
-        stream: mpsc::Sender<Result<RecordBatch, BlpError>>,
+        stream: mpsc::Sender<Result<SubscriptionUpdate, BlpError>>,
     ) -> Result<(Vec<SlabKey>, Vec<Arc<SubscriptionMetrics>>), BlpError> {
         let mut sub_list = SubscriptionList::new();
 
@@ -357,6 +356,9 @@ impl SubscriptionWorker {
             );
             let metrics_arc = state.metrics.clone();
             let key = self.subs.insert(state);
+            if let Some(state) = self.subs.get_mut(key) {
+                state.set_topic_id(key as u32);
+            }
 
             let cid = DispatchKey::from_slab_key(key).to_correlation_id();
             if let Err(e) = sub_list.add(topic, &field_refs, &options_str, &cid) {
@@ -1199,7 +1201,7 @@ impl SubscriptionCommandHandle {
         options: Vec<String>,
         flush_threshold: Option<usize>,
         overflow_policy: Option<OverflowPolicy>,
-        stream: mpsc::Sender<Result<RecordBatch, BlpError>>,
+        stream: mpsc::Sender<Result<SubscriptionUpdate, BlpError>>,
         status: SharedSubscriptionStatus,
     ) -> Result<(Vec<SlabKey>, Vec<Arc<SubscriptionMetrics>>), BlpAsyncError> {
         let (reply_tx, reply_rx) = oneshot::channel();
@@ -1237,7 +1239,7 @@ impl SubscriptionCommandHandle {
         options: Vec<String>,
         flush_threshold: Option<usize>,
         overflow_policy: Option<OverflowPolicy>,
-        stream: mpsc::Sender<Result<RecordBatch, BlpError>>,
+        stream: mpsc::Sender<Result<SubscriptionUpdate, BlpError>>,
         status: SharedSubscriptionStatus,
     ) -> Result<(Vec<SlabKey>, Vec<Arc<SubscriptionMetrics>>), BlpAsyncError> {
         let (reply_tx, reply_rx) = oneshot::channel();
@@ -1583,7 +1585,7 @@ impl SessionClaim {
         options: Vec<String>,
         flush_threshold: Option<usize>,
         overflow_policy: Option<OverflowPolicy>,
-        stream: mpsc::Sender<Result<RecordBatch, BlpError>>,
+        stream: mpsc::Sender<Result<SubscriptionUpdate, BlpError>>,
         status: SharedSubscriptionStatus,
     ) -> Result<(Vec<SlabKey>, Vec<Arc<SubscriptionMetrics>>), BlpAsyncError> {
         self.command_handle()?
@@ -1612,7 +1614,7 @@ impl SessionClaim {
         options: Vec<String>,
         flush_threshold: Option<usize>,
         overflow_policy: Option<OverflowPolicy>,
-        stream: mpsc::Sender<Result<RecordBatch, BlpError>>,
+        stream: mpsc::Sender<Result<SubscriptionUpdate, BlpError>>,
         status: SharedSubscriptionStatus,
     ) -> Result<(Vec<SlabKey>, Vec<Arc<SubscriptionMetrics>>), BlpAsyncError> {
         self.command_handle()?

--- a/crates/xbbg-async/src/tests.rs
+++ b/crates/xbbg-async/src/tests.rs
@@ -2,10 +2,12 @@
 //!
 //! These tests don't require a Bloomberg connection.
 
-use crate::engine::state::SubscriptionState;
+use crate::engine::state::{
+    subscription_update_to_record_batch, FieldKind, FieldLayout, FieldMeta, SubscriptionUpdate,
+};
 use crate::engine::{EngineConfig, OutputFormat, OverflowPolicy, ServerAddr, Transport};
 use arrow::datatypes::{DataType, TimeUnit};
-use tokio::sync::mpsc;
+use std::sync::Arc;
 
 // =========================================================================
 // Engine configuration tests
@@ -315,26 +317,20 @@ fn test_blp_async_error_is_send_sync() {
 }
 
 #[test]
-fn test_subscription_flush_emits_utc_timestamp_column() {
-    let (tx, mut rx) = mpsc::channel(1);
-    let mut state = SubscriptionState::new(
-        "AAPL US Equity".to_string(),
-        vec!["LAST_PRICE".to_string()],
-        tx,
-        10,
-        false,
-    );
+fn test_subscription_arrow_adapter_emits_utc_timestamp_column() {
+    let update = SubscriptionUpdate {
+        timestamp_us: 1_717_242_600_000_000,
+        topic_id: 0,
+        topic: Arc::from("AAPL US Equity"),
+        layout: Arc::new(FieldLayout::new(
+            1,
+            vec![FieldMeta::new("LAST_PRICE", 0, FieldKind::Unknown)],
+        )),
+        values: Box::from([]),
+    };
 
-    state.timestamp_builder.append_value(1_717_242_600_000_000);
-    state.topic_builder.append_value("AAPL US Equity");
-    state.pending_count = 1;
-
-    state.flush();
-
-    let batch = rx
-        .try_recv()
-        .expect("subscription flush should emit a batch")
-        .expect("subscription flush should emit a successful batch");
+    let batch = subscription_update_to_record_batch(&update)
+        .expect("subscription update should adapt to a RecordBatch");
     let expected = DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into()));
 
     assert_eq!(batch.schema().field(0).data_type(), &expected);

--- a/js-xbbg/src/index.ts
+++ b/js-xbbg/src/index.ts
@@ -66,6 +66,7 @@ import type {
   NativeArrowZeroCopyBatch,
   NativeEngine,
   NativeSubscription,
+  NativeSubscriptionUpdate,
 } from './napi';
 
 const nodeRequire = createRequire(__filename);
@@ -706,12 +707,84 @@ async function getConfiguredEngine(): Promise<Engine> {
 
 // ── Subscription class ──────────────────────────────────────────────────
 
-export class Subscription implements AsyncIterator<Table>, AsyncIterable<Table> {
-  private readonly _inner: NativeSubscription;
+export type TickValue = null | boolean | number | bigint | string | Date;
 
-  public constructor(inner: NativeSubscription) {
-    this._inner = inner;
+export class FieldHandle {
+  public constructor(public readonly name: string) {}
+}
+
+export class Tick {
+  private readonly _positions: Map<string, number>;
+
+  public constructor(private readonly _update: NativeSubscriptionUpdate) {
+    this._positions = new Map(_update.fields.map((field, index) => [field, index]));
   }
+
+  public get topic(): string {
+    return this._update.topic;
+  }
+
+  public get timestampUs(): number {
+    return this._update.timestampUs;
+  }
+
+  public get layoutVersion(): number {
+    return this._update.layoutVersion;
+  }
+
+  public get(field: string | FieldHandle): TickValue {
+    const name = typeof field === 'string' ? field : field.name;
+    const index = this._positions.get(name);
+    if (index === undefined) return null;
+    const value = this._update.values[index] ?? null;
+    const kind = this._update.valueKinds[index] ?? 'unknown';
+    if (value === null) return null;
+    if (kind === 'i64' || kind === 'time64_us' || kind === 'timestamp_us') {
+      try {
+        return BigInt(String(value));
+      } catch {
+        return null;
+      }
+    }
+    if (kind === 'date32' && typeof value === 'number') {
+      return new Date(Date.UTC(1970, 0, 1 + value));
+    }
+    return value;
+  }
+
+  public f64(field: string | FieldHandle): number | null {
+    const value = this.get(field);
+    if (value === null) return null;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  public i64(field: string | FieldHandle): bigint | null {
+    const value = this.get(field);
+    if (value === null) return null;
+    try {
+      return BigInt(String(value));
+    } catch {
+      return null;
+    }
+  }
+
+  public str(field: string | FieldHandle): string | null {
+    const value = this.get(field);
+    return value === null ? null : String(value);
+  }
+
+  public toObject(): Record<string, unknown> {
+    const out: Record<string, unknown> = { topic: this.topic, timestampUs: this.timestampUs };
+    for (const field of this._update.fields) {
+      out[field] = this.get(field);
+    }
+    return out;
+  }
+}
+
+export class ArrowSubscription implements AsyncIterator<Table>, AsyncIterable<Table> {
+  public constructor(private readonly _inner: NativeSubscription) {}
 
   public async next(): Promise<IteratorResult<Table>> {
     try {
@@ -720,6 +793,39 @@ export class Subscription implements AsyncIterator<Table>, AsyncIterable<Table> 
         return { done: true, value: undefined };
       }
       return { done: false, value: toArrowTableFromNative(batch) };
+    } catch (err) {
+      throw wrapError(err);
+    }
+  }
+
+  public async unsubscribe(drain = false): Promise<Table[]> {
+    try {
+      const drained = await this._inner.unsubscribeArrow(drain);
+      return drained?.map(toArrowTableFromNative) ?? [];
+    } catch (err) {
+      throw wrapError(err);
+    }
+  }
+
+  public [Symbol.asyncIterator](): this {
+    return this;
+  }
+}
+
+export class Subscription implements AsyncIterator<Tick>, AsyncIterable<Tick> {
+  private readonly _inner: NativeSubscription;
+
+  public constructor(inner: NativeSubscription) {
+    this._inner = inner;
+  }
+
+  public async next(): Promise<IteratorResult<Tick>> {
+    try {
+      const update = await this._inner.nextUpdate();
+      if (update === null) {
+        return { done: true, value: undefined };
+      }
+      return { done: false, value: new Tick(update) };
     } catch (err) {
       throw wrapError(err);
     }
@@ -741,16 +847,24 @@ export class Subscription implements AsyncIterator<Table>, AsyncIterable<Table> 
     }
   }
 
-  public async unsubscribe(drain = false): Promise<Table[]> {
+  public async unsubscribe(drain = false): Promise<Tick[]> {
     try {
-      const drained = await this._inner.unsubscribeArrow(drain);
+      const drained = await this._inner.unsubscribe(drain);
       if (drained === null) {
         return [];
       }
-      return drained.map(toArrowTableFromNative);
+      return drained.map((update) => new Tick(update));
     } catch (err) {
       throw wrapError(err);
     }
+  }
+
+  public field(name: string): FieldHandle {
+    return new FieldHandle(name);
+  }
+
+  public arrow(): ArrowSubscription {
+    return new ArrowSubscription(this._inner);
   }
 
   public get tickers(): string[] {
@@ -1133,10 +1247,26 @@ export class Engine {
   public async subscribe(
     tickers: readonly string[],
     fields: readonly string[],
-    options: Pick<StreamOptions, 'allFields'> = {},
+    options: StreamOptions = {},
   ): Promise<Subscription> {
     try {
-      const stream = await this._inner.subscribe(tickers, fields, options.allFields);
+      const useOptions =
+        options.options !== undefined ||
+        options.flushThreshold !== undefined ||
+        options.overflowPolicy !== undefined ||
+        options.streamCapacity !== undefined;
+      const stream = useOptions
+        ? await this._inner.subscribeWithOptions(
+            '//blp/mktdata',
+            tickers,
+            fields,
+            options.options,
+            options.flushThreshold,
+            options.overflowPolicy,
+            options.streamCapacity,
+            options.allFields,
+          )
+        : await this._inner.subscribe(tickers, fields, options.allFields);
       return new Subscription(stream);
     } catch (err) {
       throw wrapError(err);
@@ -1653,7 +1783,7 @@ export async function bdtick(ticker: string, options: BdtickOptions = {}): Promi
 export async function asubscribe(
   tickers: string | readonly string[],
   fields: string | readonly string[],
-  options: Pick<StreamOptions, 'allFields'> = {},
+  options: StreamOptions = {},
 ): Promise<Subscription> {
   const engine = await getConfiguredEngine();
   return await engine.subscribe(toStringArray(tickers), toStringArray(fields), options);
@@ -1662,7 +1792,7 @@ export async function asubscribe(
 export async function subscribe(
   tickers: string | readonly string[],
   fields: string | readonly string[],
-  options: Pick<StreamOptions, 'allFields'> = {},
+  options: StreamOptions = {},
 ): Promise<Subscription> {
   return await asubscribe(tickers, fields, options);
 }

--- a/js-xbbg/src/napi.ts
+++ b/js-xbbg/src/napi.ts
@@ -61,10 +61,25 @@ export interface NativeArrowZeroCopyBatch {
   readonly columns: NativeArrowColumn[];
 }
 
+export type NativeUpdateValue = null | boolean | number | string;
+
+export interface NativeSubscriptionUpdate {
+  readonly kind: 'update';
+  readonly topic: string;
+  readonly topicId: number;
+  readonly timestampUs: number;
+  readonly layoutVersion: number;
+  readonly fields: readonly string[];
+  readonly values: readonly NativeUpdateValue[];
+  readonly valueKinds: readonly string[];
+}
+
 export interface NativeSubscription {
+  nextUpdate(): Promise<NativeSubscriptionUpdate | null>;
   nextArrow(): Promise<NativeArrowZeroCopyBatch | null>;
   add(tickers: readonly string[]): Promise<void>;
   remove(tickers: readonly string[]): Promise<void>;
+  unsubscribe(drain: boolean): Promise<NativeSubscriptionUpdate[] | null>;
   unsubscribeArrow(drain: boolean): Promise<NativeArrowZeroCopyBatch[] | null>;
   readonly tickers: string[];
   readonly fields: string[];

--- a/js-xbbg/test/smoke.test.ts
+++ b/js-xbbg/test/smoke.test.ts
@@ -299,26 +299,23 @@ describe('native Arrow zero-copy table construction', () => {
     expect(Array.from(table.getChild('PAYLOAD')?.get(1) ?? [])).toEqual([0xbe, 0xef, 0x01]);
   });
 
-  it('Subscription.next uses native zero-copy batches', async () => {
-    const values = new Int32Array([42]);
-    const batch: NativeArrowZeroCopyBatch = {
-      kind: 'zeroCopy',
-      numRows: 1,
-      columns: [
-        {
-          name: 'answer',
-          type: 'int32',
-          nullable: false,
-          length: 1,
-          nullCount: 0,
-          data: typedBuffer(values),
-        },
-      ],
-    };
+  it('Subscription.next uses native updates', async () => {
     const sub = new api.Subscription({
-      nextArrow: async () => await Promise.resolve(batch),
+      nextUpdate: async () =>
+        await Promise.resolve({
+          kind: 'update',
+          topic: 'XBTUSD Curncy',
+          topicId: 1,
+          timestampUs: 123,
+          layoutVersion: 1,
+          fields: ['answer'],
+          values: [42],
+          valueKinds: ['i32'],
+        }),
+      nextArrow: async () => await Promise.resolve(null),
       add: async () => {},
       remove: async () => {},
+      unsubscribe: async () => await Promise.resolve(null),
       unsubscribeArrow: async () => await Promise.resolve(null),
       tickers: [],
       fields: [],
@@ -329,10 +326,11 @@ describe('native Arrow zero-copy table construction', () => {
     const result = await sub.next();
 
     expect(result.done).toBe(false);
-    expect(result.value.getChild('answer')?.get(0)).toBe(42);
+    expect(result.value?.topic).toBe('XBTUSD Curncy');
+    expect(result.value?.f64('answer')).toBe(42);
   });
 
-  it('Subscription.unsubscribe drains native zero-copy batches', async () => {
+  it('Subscription.arrow drains native zero-copy batches', async () => {
     const values = new Int32Array([7]);
     const batch: NativeArrowZeroCopyBatch = {
       kind: 'zeroCopy',
@@ -349,9 +347,11 @@ describe('native Arrow zero-copy table construction', () => {
       ],
     };
     const sub = new api.Subscription({
+      nextUpdate: async () => await Promise.resolve(null),
       nextArrow: async () => await Promise.resolve(null),
       add: async () => {},
       remove: async () => {},
+      unsubscribe: async () => await Promise.resolve(null),
       unsubscribeArrow: async (drain) => await Promise.resolve(drain ? [batch] : null),
       tickers: [],
       fields: [],
@@ -359,7 +359,7 @@ describe('native Arrow zero-copy table construction', () => {
       stats: { messagesReceived: 0, droppedBatches: 0, batchesSent: 0, slowConsumer: false },
     });
 
-    const drained = await sub.unsubscribe(true);
+    const drained = await sub.arrow().unsubscribe(true);
 
     expect(drained).toHaveLength(1);
     expect(drained[0]?.getChild('answer')?.get(0)).toBe(7);

--- a/py-xbbg/src/xbbg/blp.py
+++ b/py-xbbg/src/xbbg/blp.py
@@ -1650,12 +1650,10 @@ class Subscription:
         return self
 
     async def __anext__(self) -> pa.RecordBatch | nw.DataFrame | dict[str, Any]:
-        """Get next batch of data."""
-        batch = await self._sub.__anext__()
-
-        # Tick mode: convert RecordBatch to dict
         if self._tick_mode:
-            return {field.name: batch.column(i)[0].as_py() for i, field in enumerate(batch.schema)}
+            return await self._sub.__anext_tick_dict__()
+
+        batch = await self._sub.__anext__()
 
         if self._raw:
             return batch
@@ -1826,6 +1824,7 @@ async def asubscribe(
     flush_threshold: int | None = None,
     stream_capacity: int | None = None,
     overflow_policy: str | None = None,
+    output: str | None = None,
 ) -> Subscription:
     """Create an async subscription to real-time market data.
 
@@ -1845,7 +1844,7 @@ async def asubscribe(
         backend: DataFrame backend for batch conversion (ignored if raw=True)
         service: Bloomberg service (e.g., '//blp/mktdata'). If provided, uses subscribe_with_options
         options: List of subscription options. If provided, uses subscribe_with_options
-        tick_mode: If True, convert batches to dicts (implies raw=True)
+        tick_mode: If True, return native dict ticks without building Arrow (implies raw=True)
         flush_threshold: Batch flush threshold (validation only in Wave 1)
         stream_capacity: Stream channel capacity (validation only in Wave 1)
         overflow_policy: Overflow policy for stream (validation only in Wave 1)
@@ -1883,6 +1882,18 @@ async def asubscribe(
         async for tick_dict in sub:
             print(tick_dict)  # {'ticker': 'AAPL US Equity', 'LAST_PRICE': 150.25, ...}
     """
+    if output is not None:
+        normalized_output = output.lower()
+        if normalized_output not in ("record_batch", "backend", "dict", "tick"):
+            raise ValueError(
+                "output must be one of 'record_batch', 'backend', 'dict', 'tick', "
+                f"got {output!r}"
+            )
+        if normalized_output in ("dict", "tick"):
+            tick_mode = True
+        elif normalized_output == "record_batch":
+            raw = True
+
     # Validate config parameters
     if flush_threshold is not None and flush_threshold < 1:
         raise ValueError("flush_threshold must be >= 1")


### PR DESCRIPTION
## Summary
- Move Rust subscription hot path to native SubscriptionUpdate transport
- Add Arrow compatibility adapter for Python/raw/table consumers
- Preserve Python defaults and add fast tick dict path
- Make JS subscriptions Tick/update-first by default with explicit arrow() adapter

## Verification
- cargo fmt -p xbbg-async -p pyo3-xbbg -p napi-xbbg
- BLPAPI_ROOT=... cargo check -p xbbg-async
- BLPAPI_ROOT=... PYO3_PYTHON=... cargo check -p pyo3-xbbg
- BLPAPI_ROOT=... cargo check -p napi-xbbg
- BLPAPI_ROOT=... cargo test -p xbbg-async subscription --lib
- BLPAPI_ROOT=... uv run --extra test pytest py-xbbg/tests/test_streaming_api.py
- npm run typecheck
- npm test
- authorized-environment smoke with XBTUSD Curncy for Python tick/raw and JS Tick/arrow

## Note
OverflowPolicy::Latest is intentionally not included; true latest/conflation semantics require a dedicated latest-slot/watch-style channel rather than mpsc approximation.