### PR TITLE
Move js-xbbg benchmark into js-xbbg/benchmarks/

### DIFF
--- a/js-xbbg/benchmarks/bench-subscription-replay.js
+++ b/js-xbbg/benchmarks/bench-subscription-replay.js
@@ -19,9 +19,9 @@ const CONSUME_MODES = new Set(['rows', 'vector', 'schema', 'none']);
 
 function usage() {
   return `Usage:
-  node scripts/bench-subscription-replay.js [--rows N] [--iterations N] [--consume rows|vector|schema|none]
-  node scripts/bench-subscription-replay.js --fixture tmp/xbtusd-ticks.jsonl [--iterations N] [--warmup-iterations N]
-  node scripts/bench-subscription-replay.js --capture-live "XBTUSD Curncy" --capture-ms 10000 --out tmp/xbtusd-ticks.jsonl
+  node benchmarks/bench-subscription-replay.js [--rows N] [--iterations N] [--consume rows|vector|schema|none]
+  node benchmarks/bench-subscription-replay.js --fixture tmp/xbtusd-ticks.jsonl [--iterations N] [--warmup-iterations N]
+  node benchmarks/bench-subscription-replay.js --capture-live "XBTUSD Curncy" --capture-ms 10000 --out tmp/xbtusd-ticks.jsonl
 
 Modes:
   synthetic      Default. Generates one tick/update at a time; no batching.

--- a/js-xbbg/package.json
+++ b/js-xbbg/package.json
@@ -17,7 +17,7 @@
     "stage:native-package": "node ./scripts/stage-native-package.js",
     "stamp:version": "node ./scripts/stamp-version.js",
     "smoke:packaged-install": "node ./scripts/smoke-packaged-install.js --packed",
-    "bench:subscription-replay": "node ./scripts/bench-subscription-replay.js",
+    "bench:subscription-replay": "node ./benchmarks/bench-subscription-replay.js",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "format": "eslint --fix .",


### PR DESCRIPTION
## Summary

Mirrors `py-xbbg/benchmarks/`. Language-specific benchmarks live in a `benchmarks/` folder next to that language's source, not in its `scripts/` folder.

## Change

- `js-xbbg/scripts/bench-subscription-replay.js` → `js-xbbg/benchmarks/bench-subscription-replay.js`
- `js-xbbg/package.json`: `bench:subscription-replay` script path updated.
- Script's own usage examples updated.

Single file, single npm script alias, two doc-string lines. No other references in the workspace.

## Test plan

- [x] `npm run bench:subscription-replay` resolves the new path (verified by grep — no remaining `scripts/bench-subscription-replay` references).
- [x] No CI workflow changes needed — the bench is invoked via the npm alias, not a hardcoded path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)