### PR TITLE
fix(streaming): align Bloomberg subscription services

### DIFF
--- a/bindings/pyo3-xbbg/src/lib.rs
+++ b/bindings/pyo3-xbbg/src/lib.rs
@@ -1454,9 +1454,9 @@ impl PyEngine {
     /// ```python
     /// sub = await engine.subscribe_with_options(
     ///     '//blp/mktvwap',
-    ///     ['AAPL US Equity'],
-    ///     ['RT_PX_VWAP', 'RT_VWAP_VOLUME'],
-    ///     ['VWAP_START_TIME=09:30', 'VWAP_END_TIME=16:00']
+    ///     ['//blp/mktvwap/ticker/IBM US Equity'],
+    ///     ['VWAP'],
+    ///     ['VWAP_START_TIME=10:00', 'VWAP_END_TIME=16:00']
     /// )
     /// async for batch in sub:
     ///     print(batch)

--- a/docs/src/content/docs/python/guides/streaming.mdx
+++ b/docs/src/content/docs/python/guides/streaming.mdx
@@ -152,6 +152,21 @@ sub = await blp.asubscribe(
 )
 ```
 
+### `conflate`
+
+Set `conflate=True` to request Bloomberg conflated market data for `//blp/mktdata`. Bloomberg samples quote-side updates (`BID`, `ASK`, `PAIRED`) on its fixed conflation interval and sends the latest quote state; trade events are still delivered as received.
+
+```python
+sub = await blp.asubscribe(
+    'ES1 Index',
+    ['BID', 'ASK', 'LAST_PRICE', 'MKTDATA_EVENT_TYPE', 'MKTDATA_EVENT_SUBTYPE'],
+    conflate=True,
+    output='tick',
+)
+```
+
+`conflate=True` is only valid for market-data subscriptions. Do not combine it with `interval=...`; Bloomberg intervalization overrides conflation.
+
 ### `flush_threshold`, `stream_capacity`, `overflow_policy`
 
 These control the backpressure pipeline between the Bloomberg SDK event thread and your Python consumer.
@@ -197,11 +212,14 @@ xbbg provides dedicated functions for Bloomberg's specialized subscription servi
 
 ### VWAP — `avwap()` / `vwap()`
 
-Streaming Volume Weighted Average Price via `//blp/mktvwap`.
+Streaming Market Volume Weighted Average Price via `//blp/mktvwap`.
+Bloomberg requires Market VWAP subscriptions to use explicit `//blp/mktvwap/ticker/...` topics and request `VWAP` as the single main field. `avwap()` handles that topic shape for plain tickers and already-qualified `//blp/mktvwap/...` topics.
+
+Default output exposes the full top-level VWAP payload Bloomberg sends, such as `VWAP`, `RT_VWAP_VOLUME`, `VWAP_NUM_TRADES_RT`, `VWAP_TURNOVER_RT`, and `VWAP_UPDATE_TIME_RT`. The request field sent to Bloomberg remains `VWAP`.
 
 ```python
-# Basic — default fields: RT_PX_VWAP, RT_VWAP_VOLUME
-sub = await blp.avwap(['AAPL US Equity'])
+# Basic — request field is VWAP; output includes the full VWAP payload
+sub = await blp.avwap('IBM US Equity')
 async for batch in sub:
     print(batch)
 await sub.unsubscribe()
@@ -210,35 +228,30 @@ await sub.unsubscribe()
 ```python
 # Custom time window
 sub = await blp.avwap(
-    ['AAPL US Equity', 'MSFT US Equity'],
-    start_time='09:30',
+    ['IBM US Equity', 'MSFT US Equity'],
+    start_time='10:00',
     end_time='16:00',
-)
-```
-
-```python
-# Request additional VWAP fields
-sub = await blp.avwap(
-    'AAPL US Equity',
-    ['RT_PX_VWAP', 'RT_VWAP_VOLUME', 'RT_VWAP_TURNOVER'],
 )
 ```
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `tickers` | required | One or more securities |
-| `fields` | `['RT_PX_VWAP', 'RT_VWAP_VOLUME']` | Fields to subscribe to |
-| `start_time` | `None` | VWAP calculation start (e.g., `'09:30'`) |
+| `tickers` | required | One or more equities. Plain tickers become `//blp/mktvwap/ticker/...`; already-qualified `//blp/mktvwap/...` topics pass through unchanged. |
+| `start_time` | `None` | VWAP calculation start (e.g., `'10:00'`) |
 | `end_time` | `None` | VWAP calculation end (e.g., `'16:00'`) |
 
 ### Market Bars — `amktbar()` / `mktbar()`
 
 Streaming real-time OHLCV bars via `//blp/mktbar`. Like `bdib()` but live as bars form.
 
-Default fields: `OPEN`, `HIGH`, `LOW`, `CLOSE`, `VOLUME`, `NUM_TRADES`.
+Bloomberg requires market-bar subscriptions to use explicit `//blp/mktbar/{identifier-type}/{identifier}` topics, request `LAST_PRICE` as the only field, and set `bar_size` in minutes. `amktbar()` handles that for you: plain tickers use the `ticker` topic type, identifier paths like `/figi/...` keep their identifier type, and already-qualified `//blp/mktbar/...` topics pass through unchanged.
+
+Market bars are event-driven. Bloomberg may emit `MarketBarStart`, intra-bar `MarketBarUpdate`, `MarketBarIntervalEnd`, and `MarketBarEnd` messages; no-trade intervals may not produce OHLC payloads until Bloomberg publishes an interval/end event.
+
+Default output exposes the full top-level market-bar payload, including fields Bloomberg sends such as `TIME`, `DATE_TIME`, `OPEN`, `HIGH`, `LOW`, `CLOSE`, `VOLUME`, and `NUMBER_OF_TICKS`. The request field sent to Bloomberg remains `LAST_PRICE`.
 
 ```python
-# 1-minute bars (default interval)
+# 1-minute bars (default bar_size)
 sub = await blp.amktbar('AAPL US Equity')
 async for batch in sub:
     print(batch)
@@ -247,8 +260,8 @@ async for batch in sub:
 ```python
 # 5-minute bars with a session window
 async with await blp.amktbar(
-    ['AAPL US Equity', 'MSFT US Equity'],
-    interval=5,
+    ['AAPL US Equity', '/figi/BBG000JB5HR2'],
+    bar_size=5,
     start_time='09:30',
     end_time='16:00',
 ) as sub:
@@ -258,8 +271,8 @@ async with await blp.amktbar(
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `tickers` | required | One or more securities |
-| `interval` | `1` | Bar interval in minutes |
+| `tickers` | required | One or more securities. Plain tickers become `//blp/mktbar/ticker/...`; `/figi/...`, `/isin/...`, etc. preserve the identifier type. |
+| `bar_size` | `1` | Bar interval in minutes |
 | `start_time` | `None` | Session start in `HH:MM` format |
 | `end_time` | `None` | Session end in `HH:MM` format |
 

--- a/js-xbbg/README.md
+++ b/js-xbbg/README.md
@@ -145,6 +145,16 @@ for await (const tick of sub) {
   console.log(tick);
 }
 
+// Conflated market data: quote updates are conflated by Bloomberg; trades still stream as received.
+const conflated = await xbbg.blp.asubscribe(
+  ['ES1 Index'],
+  ['BID', 'ASK', 'LAST_PRICE', 'MKTDATA_EVENT_TYPE', 'MKTDATA_EVENT_SUBTYPE'],
+  { conflate: true },
+);
+for await (const tick of conflated) {
+  console.log(tick);
+}
+
 // CDX analytics
 const cdxInfo = await xbbg.ext.cdx.acdx_info('CDX IG CDSI GEN 5Y Corp');
 const cdxPricing = await xbbg.ext.cdx.acdx_pricing('CDX IG CDSI GEN 5Y Corp');

--- a/js-xbbg/src/errors.ts
+++ b/js-xbbg/src/errors.ts
@@ -50,6 +50,9 @@ export class BlpTimeoutError extends BlpError {}
 export class BlpInternalError extends BlpError {}
 
 export function wrapError(napiError: unknown): BlpError {
+  if (napiError instanceof BlpError) {
+    return napiError;
+  }
   const msg =
     napiError instanceof Error
       ? napiError.message

--- a/js-xbbg/src/index.ts
+++ b/js-xbbg/src/index.ts
@@ -370,6 +370,9 @@ const TA_DEFAULTS: Readonly<Record<string, Readonly<StudyParams>>> = Object.free
   }),
 });
 
+const MKTDATA_SERVICE = '//blp/mktdata';
+
+
 // ── Helpers ─────────────────────────────────────────────────────────────
 
 function toArrowTableFromNative(batch: NativeArrowZeroCopyBatch): Table {
@@ -443,6 +446,54 @@ function toStringArray(value: string | readonly string[] | null | undefined): st
     return [];
   }
   return [toRequestString(value)];
+}
+
+function subscriptionOptionKey(option: string): string {
+  return normalizeSubscriptionOption(option).split('=')[0]?.trim().toLowerCase() ?? '';
+}
+
+function normalizeSubscriptionOption(option: string): string {
+  let clean = option.trim();
+  while (clean.startsWith('&')) {
+    clean = clean.slice(1).trim();
+  }
+  return clean;
+}
+
+function buildStreamSubscriptionOptions(
+  service: string,
+  options: StreamOptions,
+): readonly string[] | undefined {
+  const rawOptions = options.options;
+  const conflate = options.conflate;
+
+  if (rawOptions === undefined && conflate !== true) {
+    return undefined;
+  }
+
+  const subscriptionOptions = (rawOptions ?? [])
+    .map((option) => normalizeSubscriptionOption(option))
+    .filter((option) => option.length > 0);
+
+  if (conflate === true) {
+    if (service !== MKTDATA_SERVICE) {
+      throw new BlpValidationError(
+        'conflate=true is only supported for //blp/mktdata subscriptions',
+        { element: 'conflate' },
+      );
+    }
+    if (subscriptionOptions.some((option) => subscriptionOptionKey(option) === 'interval')) {
+      throw new BlpValidationError(
+        'conflate=true cannot be combined with interval options; intervalization overrides conflation',
+        { element: 'conflate' },
+      );
+    }
+    if (!subscriptionOptions.some((option) => subscriptionOptionKey(option) === 'conflate')) {
+      subscriptionOptions.push('conflate');
+    }
+  }
+
+  return subscriptionOptions.length > 0 || rawOptions !== undefined ? subscriptionOptions : undefined;
 }
 
 function normalizeConfigureArgs(
@@ -1258,17 +1309,18 @@ export class Engine {
     options: StreamOptions = {},
   ): Promise<Subscription> {
     try {
+      const subscriptionOptions = buildStreamSubscriptionOptions(MKTDATA_SERVICE, options);
       const useOptions =
-        options.options !== undefined ||
+        subscriptionOptions !== undefined ||
         options.flushThreshold !== undefined ||
         options.overflowPolicy !== undefined ||
         options.streamCapacity !== undefined;
       const stream = useOptions
         ? await this._inner.subscribeWithOptions(
-            '//blp/mktdata',
+            MKTDATA_SERVICE,
             tickers,
             fields,
-            options.options,
+            subscriptionOptions,
             options.flushThreshold,
             options.overflowPolicy,
             options.streamCapacity,
@@ -1322,10 +1374,10 @@ export class Engine {
     options: StreamOptions = {},
   ): Promise<Subscription> {
     return await this.subscribeWithOptions(
-      '//blp/mktdata',
+      MKTDATA_SERVICE,
       tickers,
       fields,
-      options.options,
+      buildStreamSubscriptionOptions(MKTDATA_SERVICE, options),
       options.flushThreshold,
       options.overflowPolicy,
       options.streamCapacity,
@@ -1342,7 +1394,7 @@ export class Engine {
       '//blp/mktvwap',
       tickers,
       fields,
-      options.options,
+      buildStreamSubscriptionOptions('//blp/mktvwap', options),
       options.flushThreshold,
       options.overflowPolicy,
       options.streamCapacity,
@@ -1355,7 +1407,7 @@ export class Engine {
       '//blp/mktbar',
       [ticker],
       options.fields ?? [],
-      options.options,
+      buildStreamSubscriptionOptions('//blp/mktbar', options),
       options.flushThreshold,
       options.overflowPolicy,
       options.streamCapacity,
@@ -1368,7 +1420,7 @@ export class Engine {
       '//blp/mktdepthdata',
       [ticker],
       options.fields ?? [],
-      options.options,
+      buildStreamSubscriptionOptions('//blp/mktdepthdata', options),
       options.flushThreshold,
       options.overflowPolicy,
       options.streamCapacity,
@@ -1381,7 +1433,7 @@ export class Engine {
       '//blp/mktlist',
       [ticker],
       options.fields ?? [],
-      options.options,
+      buildStreamSubscriptionOptions('//blp/mktlist', options),
       options.flushThreshold,
       options.overflowPolicy,
       options.streamCapacity,

--- a/js-xbbg/src/types.ts
+++ b/js-xbbg/src/types.ts
@@ -261,6 +261,7 @@ export interface RequestOptions {
 
 export interface StreamOptions {
   options?: readonly string[];
+  conflate?: boolean;
   flushThreshold?: number;
   overflowPolicy?: string;
   streamCapacity?: number;

--- a/js-xbbg/test/live.test.ts
+++ b/js-xbbg/test/live.test.ts
@@ -787,6 +787,24 @@ describe('js-xbbg live Bloomberg API', () => {
         console.log(`  stream columns=${cols.join(', ')}`);
       }));
 
+    it('stream supports conflated market data option', async (t) =>
+      runCase(t, 'stream conflate option', async () => {
+        const sub = (
+          await engine!.stream(
+            [CONFIG.streaming_ticker],
+            ['LAST_PRICE', 'BID', 'ASK', 'MKTDATA_EVENT_TYPE', 'MKTDATA_EVENT_SUBTYPE'],
+            { conflate: true },
+          )
+        ).arrow();
+        const result: any = await nextWithTimeout(sub, 20_000);
+        await sub.unsubscribe(true);
+        assert.ok(result && !result.done, 'Expected at least one conflated tick batch');
+        const cols = columnsOf(result.value);
+        assert.ok(cols.includes('MKTDATA_EVENT_TYPE'), `columns=${cols.join(', ')}`);
+        console.log(`  conflate stream columns=${cols.join(', ')}`);
+      }));
+
+
     it('stream continues while BDP and BDH requests run concurrently', async (t) =>
       runCase(t, 'stream concurrent with reference requests', async () => {
         const sub = await engine!.stream([CONFIG.streaming_ticker], ['LAST_PRICE']);

--- a/js-xbbg/test/smoke.test.ts
+++ b/js-xbbg/test/smoke.test.ts
@@ -127,6 +127,11 @@ describe('@xbbg/core surface', () => {
     }
   });
 
+  it('wrapError preserves typed errors', () => {
+    const err = new api.BlpValidationError('typed validation');
+    expect(api.wrapError(err)).toBe(err);
+  });
+
   it('exposes version, connect, setLogLevel, getLogLevel as functions', () => {
     expect(typeof api.connect).toBe('function');
     expect(typeof api.version).toBe('function');
@@ -193,6 +198,106 @@ describe('@xbbg/core surface', () => {
     }
   });
 });
+
+describe('conflated market data options', () => {
+  function fakeNativeSubscription(): any {
+    return {
+      add: async () => undefined,
+      remove: async () => undefined,
+      nextUpdate: async () => null,
+      nextArrow: async () => null,
+      unsubscribe: async () => [],
+      unsubscribeArrow: async () => [],
+      tickers: ['ES1 Index'],
+      fields: ['BID', 'ASK'],
+      isActive: true,
+      stats: {
+        messagesReceived: 0,
+        droppedBatches: 0,
+        batchesSent: 0,
+        slowConsumer: false,
+        dataLossEvents: 0,
+        lastMessageUs: 0,
+        lastDataLossUs: 0,
+        effectiveOverflowPolicy: 'drop_newest',
+      },
+    };
+  }
+
+  function fakeEngine(captured: Record<string, unknown>): api.Engine {
+    const engine = Object.create(api.Engine.prototype) as api.Engine;
+    (engine as unknown as { _inner: unknown })._inner = {
+      subscribe: async (tickers: readonly string[], fields: readonly string[], allFields?: boolean) => {
+        captured.subscribe = { tickers, fields, allFields };
+        return fakeNativeSubscription();
+      },
+      subscribeWithOptions: async (
+        service: string,
+        tickers: readonly string[],
+        fields: readonly string[],
+        options?: readonly string[],
+        flushThreshold?: number,
+        overflowPolicy?: string,
+        streamCapacity?: number,
+        allFields?: boolean,
+      ) => {
+        captured.subscribeWithOptions = {
+          service,
+          tickers,
+          fields,
+          options,
+          flushThreshold,
+          overflowPolicy,
+          streamCapacity,
+          allFields,
+        };
+        return fakeNativeSubscription();
+      },
+    };
+    return engine;
+  }
+
+  it('adds the conflate Bloomberg option for mktdata subscriptions', async () => {
+    const captured: Record<string, unknown> = {};
+    await fakeEngine(captured).subscribe(['ES1 Index'], ['BID', 'ASK'], { conflate: true });
+
+    expect(captured.subscribe).toBeUndefined();
+    expect(captured.subscribeWithOptions).toMatchObject({
+      service: '//blp/mktdata',
+      tickers: ['ES1 Index'],
+      fields: ['BID', 'ASK'],
+      options: ['conflate'],
+    });
+  });
+
+  it('normalizes ampersand conflate and avoids duplicates', async () => {
+    const captured: Record<string, unknown> = {};
+    await fakeEngine(captured).subscribe(['ES1 Index'], ['BID', 'ASK'], {
+      options: ['&conflate'],
+      conflate: true,
+    });
+
+    expect(captured.subscribeWithOptions).toMatchObject({
+      options: ['conflate'],
+    });
+  });
+
+  it('rejects conflate for non-mktdata helpers', async () => {
+    await expect(
+      fakeEngine({}).vwap(['IBM US Equity'], ['VWAP'], { conflate: true }),
+    ).rejects.toBeInstanceOf(api.BlpValidationError);
+  });
+
+  it('rejects conflate with interval options', async () => {
+    await expect(
+      fakeEngine({}).subscribe(['ES1 Index'], ['BID', 'ASK'], {
+        options: ['interval=5'],
+        conflate: true,
+      }),
+    ).rejects.toBeInstanceOf(api.BlpValidationError);
+  });
+});
+
 
 describe('native Arrow zero-copy table construction', () => {
   function typedBuffer(view: ArrayBufferView): Buffer {

--- a/py-xbbg/src/xbbg/blp.py
+++ b/py-xbbg/src/xbbg/blp.py
@@ -850,6 +850,108 @@ def _normalize_fields(fields: str | Sequence[str] | None) -> list[str]:
     return list(fields)
 
 
+_SUBSCRIPTION_IDENTIFIER_PREFIXES = ("ticker/", "figi/", "isin/", "cusip/", "sedol/")
+
+
+def _normalize_service_topic(service: Service, ticker: str, label: str) -> str:
+    """Normalize a security identifier into an explicit Bloomberg service topic."""
+    topic = ticker.strip()
+    service_uri = service.value
+    if topic.startswith("//"):
+        if not topic.startswith(f"{service_uri}/"):
+            raise ValueError(f"{label} topic must start with {service_uri}/, got {ticker!r}")
+        return topic
+    if topic.startswith("/"):
+        return f"{service_uri}{topic}"
+
+    lower_topic = topic.lower()
+    if lower_topic.startswith(_SUBSCRIPTION_IDENTIFIER_PREFIXES):
+        return f"{service_uri}/{topic}"
+
+    return f"{service_uri}/ticker/{topic}"
+
+
+def _normalize_service_topics(service: Service, tickers: str | Sequence[str], label: str) -> list[str]:
+    """Normalize identifiers into explicit Bloomberg service topics."""
+    return [_normalize_service_topic(service, ticker, label) for ticker in _normalize_tickers(tickers)]
+
+
+def _normalize_mktbar_topics(tickers: str | Sequence[str]) -> list[str]:
+    """Normalize market-bar identifiers into explicit service topics."""
+    return _normalize_service_topics(Service.MKTBAR, tickers, "market-bar")
+
+
+def _normalize_mktvwap_topics(tickers: str | Sequence[str]) -> list[str]:
+    """Normalize market-VWAP identifiers into explicit service topics."""
+    return _normalize_service_topics(Service.MKTVWAP, tickers, "market-VWAP")
+
+
+def _get_subscription_option(options: Sequence[str] | None, name: str) -> str | None:
+    """Return a subscription option value by case-insensitive option name."""
+    for option in options or []:
+        key, separator, value = option.partition("=")
+        if key.strip().lower() != name.lower():
+            continue
+        if not separator or not value.strip():
+            raise ValueError(f"{name} option must be provided as {name}=<value>")
+        return value.strip()
+    return None
+
+
+def _subscription_option_key(option: str) -> str:
+    """Return the case-insensitive key for a Bloomberg subscription option."""
+    return option.strip().lstrip("&").partition("=")[0].strip().lower()
+
+
+def _normalize_subscription_options(
+    options: Sequence[str] | None,
+    *,
+    conflate: bool = False,
+    service: str | None = None,
+) -> list[str] | None:
+    """Normalize high-level subscription options before passing them to Bloomberg."""
+    if options is None and not conflate:
+        return None
+
+    normalized: list[str] = []
+    for option in options or []:
+        clean_option = option.strip()
+        if not clean_option:
+            continue
+        if clean_option.startswith("&"):
+            clean_option = clean_option[1:].strip()
+        normalized.append(clean_option)
+
+    if conflate:
+        effective_service = service or Service.MKTDATA.value
+        if effective_service != Service.MKTDATA.value:
+            raise ValueError("conflate=True is only supported for //blp/mktdata subscriptions")
+        if any(_subscription_option_key(option) == "interval" for option in normalized):
+            raise ValueError("conflate=True cannot be combined with interval options; intervalization overrides conflation")
+        if not any(_subscription_option_key(option) == "conflate" for option in normalized):
+            normalized.append("conflate")
+
+    return normalized
+
+
+def _validate_mktbar_bar_size(bar_size: int) -> None:
+    """Validate Bloomberg's documented market-bar interval bounds."""
+    if not 1 <= bar_size <= 1440:
+        raise ValueError("bar_size must be between 1 and 1440 minutes")
+
+
+def _validate_mktbar_options(options: Sequence[str] | None) -> None:
+    """Validate Bloomberg's required market-bar subscription options."""
+    raw_bar_size = _get_subscription_option(options, "bar_size")
+    if raw_bar_size is None:
+        raise ValueError("//blp/mktbar subscriptions require a bar_size option")
+    try:
+        bar_size = int(raw_bar_size)
+    except ValueError as exc:
+        raise ValueError("bar_size must be an integer number of minutes") from exc
+    _validate_mktbar_bar_size(bar_size)
+
+
 # Cache for valid request elements per (service, operation)
 _VALID_ELEMENTS_CACHE: dict[tuple[str, str], set[str]] = {}
 
@@ -2164,7 +2266,14 @@ class Subscription:
         await sub.unsubscribe()
     """
 
-    def __init__(self, py_sub, raw: bool, backend: Backend | None, tick_mode: bool = False):
+    def __init__(
+        self,
+        py_sub,
+        raw: bool,
+        backend: Backend | None,
+        tick_mode: bool = False,
+        topic_normalizer: Callable[[str | Sequence[str]], list[str]] | None = None,
+    ):
         """Initialize subscription wrapper.
 
         Args:
@@ -2172,11 +2281,13 @@ class Subscription:
             raw: If True, yield raw Arrow batches
             backend: DataFrame backend for conversion (if not raw)
             tick_mode: If True, convert batches to dicts (implies raw=True)
+            topic_normalizer: Normalizes add/remove inputs to subscribed Bloomberg topics
         """
         self._sub = py_sub
         self._raw = raw
         self._backend = backend
         self._tick_mode = tick_mode
+        self._topic_normalizer = topic_normalizer or _normalize_tickers
 
     def __aiter__(self):
         return self
@@ -2199,7 +2310,7 @@ class Subscription:
         Args:
             tickers: Single ticker or list of tickers to add
         """
-        ticker_list = _normalize_tickers(tickers)
+        ticker_list = self._topic_normalizer(tickers)
         logger.debug("subscription add: %s", ticker_list)
         await self._sub.add(ticker_list)
 
@@ -2209,7 +2320,7 @@ class Subscription:
         Args:
             tickers: Single ticker or list of tickers to remove
         """
-        ticker_list = _normalize_tickers(tickers)
+        ticker_list = self._topic_normalizer(tickers)
         logger.debug("subscription remove: %s", ticker_list)
         await self._sub.remove(ticker_list)
 
@@ -2350,8 +2461,9 @@ async def asubscribe(
     raw: bool = False,
     all_fields: bool = False,
     backend: Backend | str | None = None,
-    service: str | None = None,
+    service: str | Service | None = None,
     options: list[str] | None = None,
+    conflate: bool = False,
     tick_mode: bool = False,
     flush_threshold: int | None = None,
     stream_capacity: int | None = None,
@@ -2374,8 +2486,12 @@ async def asubscribe(
         raw: If True, yield raw Arrow RecordBatches for max performance
         all_fields: If True, expose all top-level scalar Bloomberg subscription fields
         backend: DataFrame backend for batch conversion (ignored if raw=True)
-        service: Bloomberg service (e.g., '//blp/mktdata'). If provided, uses subscribe_with_options
+        service: Bloomberg service (e.g., '//blp/mktdata'). For BPS services
+            such as ``//blp/mktbar`` and ``//blp/mktvwap``, tickers are
+            normalized to explicit service topics.
         options: List of subscription options. If provided, uses subscribe_with_options
+        conflate: If True, request Bloomberg conflated market data for //blp/mktdata.
+            Quote updates are conflated by Bloomberg; trades are still delivered as received.
         tick_mode: If True, return native dict ticks without building Arrow (implies raw=True)
         flush_threshold: Batch flush threshold (validation only in Wave 1)
         stream_capacity: Stream channel capacity (validation only in Wave 1)
@@ -2438,18 +2554,38 @@ async def asubscribe(
         )
         flush_threshold = 1
 
-    ticker_list = _normalize_tickers(tickers)
+    subscription_service = service.value if isinstance(service, Service) else service
+    effective_subscription_service = subscription_service or Service.MKTDATA.value
+    subscription_options = _normalize_subscription_options(
+        options,
+        conflate=conflate,
+        service=effective_subscription_service,
+    )
+    if subscription_service == Service.MKTBAR.value:
+        topic_normalizer = _normalize_mktbar_topics
+    elif subscription_service == Service.MKTVWAP.value:
+        topic_normalizer = _normalize_mktvwap_topics
+    else:
+        topic_normalizer = _normalize_tickers
+
+    ticker_list = topic_normalizer(tickers)
     field_list = _normalize_fields(fields)
+    if subscription_service == Service.MKTBAR.value:
+        if field_list != ["LAST_PRICE"]:
+            raise ValueError("//blp/mktbar subscriptions must request only LAST_PRICE")
+        _validate_mktbar_options(subscription_options)
+    elif subscription_service == Service.MKTVWAP.value and field_list != ["VWAP"]:
+        raise ValueError("//blp/mktvwap subscriptions must request only VWAP")
 
     effective_backend = _resolve_backend(backend)
 
     engine = _get_engine()
     logger.debug("subscribe: tickers=%s fields=%s", ticker_list, field_list)
 
-    # Use subscribe_with_options if service, options, or config params provided
+    # Use subscribe_with_options if service, subscription options, or config params provided
     if (
-        service is not None
-        or options is not None
+        subscription_service is not None
+        or subscription_options is not None
         or flush_threshold is not None
         or stream_capacity is not None
         or overflow_policy is not None
@@ -2465,16 +2601,22 @@ async def asubscribe(
             if v is not None
         }
         py_sub = await engine.subscribe_with_options(
-            service or "//blp/mktdata",
+            subscription_service or "//blp/mktdata",
             ticker_list,
             field_list,
-            options or [],
+            subscription_options or [],
             **opt_kwargs,
         )
     else:
         py_sub = await engine.subscribe(ticker_list, field_list, all_fields=all_fields)
 
-    return Subscription(py_sub, raw=raw or tick_mode, backend=effective_backend, tick_mode=tick_mode)
+    return Subscription(
+        py_sub,
+        raw=raw or tick_mode,
+        backend=effective_backend,
+        tick_mode=tick_mode,
+        topic_normalizer=topic_normalizer,
+    )
 
 
 async def astream(
@@ -2486,6 +2628,7 @@ async def astream(
     backend: Backend | str | None = None,
     callback: Callable[[Any], None] | None = None,
     tick_mode: bool = False,
+    conflate: bool = False,
     flush_threshold: int | None = None,
     stream_capacity: int | None = None,
     overflow_policy: str | None = None,
@@ -2503,6 +2646,7 @@ async def astream(
         backend: DataFrame backend for batch conversion
         callback: Optional callback function to invoke on each batch
         tick_mode: If True, convert batches to dicts
+        conflate: If True, request Bloomberg conflated market data for //blp/mktdata.
 
     Yields:
         Batches of market data (RecordBatch, DataFrame, or dict)
@@ -2530,6 +2674,7 @@ async def astream(
         all_fields=all_fields,
         backend=backend,
         tick_mode=tick_mode,
+        conflate=conflate,
         flush_threshold=flush_threshold,
         stream_capacity=stream_capacity,
         overflow_policy=overflow_policy,
@@ -2552,6 +2697,7 @@ def stream(
     backend: Backend | str | None = None,
     callback: Callable[[Any], None] | None = None,
     tick_mode: bool = False,
+    conflate: bool = False,
     flush_threshold: int | None = None,
     stream_capacity: int | None = None,
     overflow_policy: str | None = None,
@@ -2569,6 +2715,7 @@ def stream(
         backend: DataFrame backend for batch conversion
         callback: Optional callback function to invoke on each batch
         tick_mode: If True, convert batches to dicts
+        conflate: If True, request Bloomberg conflated market data for //blp/mktdata.
 
     Yields:
         Batches of market data
@@ -2596,6 +2743,7 @@ def stream(
                 backend=backend,
                 callback=callback,
                 tick_mode=tick_mode,
+                conflate=conflate,
                 flush_threshold=flush_threshold,
                 stream_capacity=stream_capacity,
                 overflow_policy=overflow_policy,
@@ -2634,53 +2782,45 @@ def stream(
 
 async def avwap(
     tickers: str | list[str],
-    fields: str | list[str] | None = None,
     *,
     start_time: str | None = None,
     end_time: str | None = None,
     raw: bool = False,
-    all_fields: bool = False,
+    all_fields: bool = True,
     backend: Backend | str | None = None,
 ) -> Subscription:
-    """Subscribe to real-time VWAP data (//blp/mktvwap).
+    """Subscribe to real-time VWAP data.
 
-    Provides streaming Volume Weighted Average Price calculations.
+    Uses Bloomberg's ``//blp/mktvwap`` service. Bloomberg requires explicit
+    Market VWAP topics (for example, ``//blp/mktvwap/ticker/IBM US Equity``)
+    and ``VWAP`` as the single requested field. Security identifiers passed
+    here are normalized to those explicit topics.
 
     Args:
-        tickers: Securities to subscribe to
-        fields: Fields to subscribe to (default: RT_PX_VWAP, RT_VWAP_VOLUME)
-        start_time: VWAP calculation start time (e.g., "09:30")
-        end_time: VWAP calculation end time (e.g., "16:00")
-        raw: If True, yield raw Arrow RecordBatches for max performance
-        all_fields: If True, expose all top-level scalar Bloomberg subscription fields
-        backend: DataFrame backend for batch conversion (ignored if raw=True)
+        tickers: Security identifier(s). Plain tickers use the ``ticker`` topic type;
+            already-qualified ``//blp/mktvwap/...`` topics pass through unchanged.
+        start_time: Optional VWAP calculation start time (e.g., "09:30").
+        end_time: Optional VWAP calculation end time (e.g., "16:00").
+        raw: If True, yield raw Arrow RecordBatches for max performance.
+        all_fields: If True, expose the full top-level VWAP payload.
+        backend: DataFrame backend for batch conversion (ignored if raw=True).
 
     Returns:
-        Subscription handle for iteration and control
+        Subscription handle for iteration and control.
 
     Example::
 
         # Basic usage - subscribe to VWAP
-        sub = await xbbg.avwap(["AAPL US Equity"])
+        sub = await xbbg.avwap("IBM US Equity")
         async for batch in sub:
             print(batch)
         await sub.unsubscribe()
 
         # With custom time window
-        sub = await xbbg.avwap(["AAPL US Equity", "MSFT US Equity"], start_time="09:30", end_time="16:00")
-
-        # With specific fields
-        sub = await xbbg.avwap("AAPL US Equity", ["RT_PX_VWAP", "RT_VWAP_VOLUME", "RT_VWAP_TURNOVER"])
+        sub = await xbbg.avwap(["IBM US Equity", "MSFT US Equity"], start_time="09:30", end_time="16:00")
     """
-    ticker_list = _normalize_tickers(tickers)
+    ticker_list = _normalize_mktvwap_topics(tickers)
 
-    # Default fields if not provided
-    if fields is None:
-        field_list = ["RT_PX_VWAP", "RT_VWAP_VOLUME"]
-    else:
-        field_list = _normalize_fields(fields)
-
-    # Build subscription options
     options: list[str] = []
     if start_time:
         options.append(f"VWAP_START_TIME={start_time}")
@@ -2693,12 +2833,12 @@ async def avwap(
     py_sub = await engine.subscribe_with_options(
         Service.MKTVWAP.value,
         ticker_list,
-        field_list,
+        ["VWAP"],
         options if options else None,
         all_fields=all_fields,
     )
 
-    return Subscription(py_sub, raw=raw, backend=effective_backend)
+    return Subscription(py_sub, raw=raw, backend=effective_backend, topic_normalizer=_normalize_mktvwap_topics)
 
 
 # =============================================================================
@@ -2709,25 +2849,29 @@ async def avwap(
 async def amktbar(
     tickers: str | list[str],
     *,
-    interval: int = 1,
+    bar_size: int = 1,
     start_time: str | None = None,
     end_time: str | None = None,
     raw: bool = False,
-    all_fields: bool = False,
+    all_fields: bool = True,
     backend: Backend | str | None = None,
 ) -> Subscription:
     """Subscribe to real-time streaming OHLC bars.
 
-    Like bdib but streaming instead of historical. Provides real-time
-    bar updates as they form during the trading day.
+    Uses Bloomberg's ``//blp/mktbar`` service. Bloomberg requires explicit
+    market-bar topics (for example, ``//blp/mktbar/ticker/ES1 Index``),
+    ``LAST_PRICE`` as the only requested field, and ``bar_size`` as the bar
+    interval option. Security identifiers passed here are normalized to those
+    explicit topics.
 
     Args:
-        tickers: Security identifier(s).
-        interval: Bar interval in minutes (default: 1).
+        tickers: Security identifier(s). Plain tickers use the ``ticker`` topic type;
+            identifiers like ``/figi/...`` keep their identifier type.
+        bar_size: Bar interval in minutes (default: 1).
         start_time: Optional start time in HH:MM format.
         end_time: Optional end time in HH:MM format.
         raw: If True, return raw xbbg ArrowRecordBatch (default: False).
-        all_fields: If True, expose all top-level scalar Bloomberg subscription fields
+        all_fields: If True, expose the full top-level market-bar payload.
         backend: DataFrame backend to return. If None, uses global default.
 
     Returns:
@@ -2736,39 +2880,38 @@ async def amktbar(
     Example::
 
         # Subscribe to 5-minute bars
-        async with await amktbar("AAPL US Equity", interval=5) as sub:
+        async with await amktbar("AAPL US Equity", bar_size=5) as sub:
             async for batch in sub:
                 print(batch)
 
         # Multiple securities
-        sub = await amktbar(["AAPL US Equity", "MSFT US Equity"], interval=1)
+        sub = await amktbar(["AAPL US Equity", "MSFT US Equity"], bar_size=1)
         async for batch in sub:
             print(batch)
     """
-    logger.debug("amktbar: tickers=%s interval=%d", tickers, interval)
+    _validate_mktbar_bar_size(bar_size)
 
-    # Normalize inputs
-    ticker_list = _normalize_tickers(tickers)
+    logger.debug("amktbar: tickers=%s bar_size=%d", tickers, bar_size)
+
+    ticker_list = _normalize_mktbar_topics(tickers)
     effective_backend = _resolve_backend(backend)
 
-    # Build subscription options
-    options: list[str] = [f"interval={interval}"]
+    options: list[str] = [f"bar_size={bar_size}"]
     if start_time:
-        options.append(f"START_TIME={start_time}")
+        options.append(f"start_time={start_time}")
     if end_time:
-        options.append(f"END_TIME={end_time}")
+        options.append(f"end_time={end_time}")
 
-    # Get engine and subscribe
     engine = _get_engine()
     py_sub = await engine.subscribe_with_options(
         Service.MKTBAR.value,
         ticker_list,
-        ["OPEN", "HIGH", "LOW", "CLOSE", "VOLUME", "NUM_TRADES"],
-        options if options else None,
+        ["LAST_PRICE"],
+        options,
         all_fields=all_fields,
     )
 
-    return Subscription(py_sub, raw=raw, backend=effective_backend)
+    return Subscription(py_sub, raw=raw, backend=effective_backend, topic_normalizer=_normalize_mktbar_topics)
 
 
 # =============================================================================

--- a/py-xbbg/tests/live/test_api.py
+++ b/py-xbbg/tests/live/test_api.py
@@ -66,6 +66,8 @@ class LiveTestConfig:
 
     # Streaming ticker — ES1 trades ~23h/day on Globex, works on most holidays
     streaming_ticker: str = "ES1 Index"
+    # Highly active FX ticker for streaming market-bar tests.
+    mktbar_ticker: str = "EURUSD Curncy"
 
     # Common fields
     price_field: str = "PX_LAST"
@@ -133,6 +135,23 @@ def assert_bqr_quote_rows(table, ticker: str) -> None:
         assert row["event_type"] in {"BID", "ASK"}
         assert isinstance(row["price"], int | float)
         assert row["size"] is None or row["size"] >= 0
+
+
+def skip_if_subscription_unavailable(exc: Exception, context: str) -> None:
+    """Skip live service tests when Bloomberg rejects the subscription environment."""
+    if isinstance(exc, AssertionError):
+        raise exc
+    message = str(exc)
+    unavailable_markers = (
+        "Subscription failed",
+        "subscribe failed",
+        "All subscriptions failed",
+        "Invalid override values",
+        "NOT_ENTITLED",
+    )
+    if any(marker in message for marker in unavailable_markers):
+        pytest.skip(f"{context} subscription not available in this Bloomberg environment: {exc}")
+    raise exc
 
 
 # =============================================================================
@@ -1021,6 +1040,36 @@ class TestStreaming:
         logger.info(f"  Received {ticks_received} ticks before unsubscribe")
 
     @pytest.mark.asyncio
+    async def test_conflated_subscription_live(self):
+        """Stream: conflate=True starts a live mktdata subscription."""
+        from xbbg import asubscribe
+
+        rows = []
+
+        async def collect_ticks():
+            async with await asubscribe(
+                CONFIG.streaming_ticker,
+                ["LAST_PRICE", "BID", "ASK", "MKTDATA_EVENT_TYPE", "MKTDATA_EVENT_SUBTYPE"],
+                conflate=True,
+                tick_mode=True,
+            ) as sub:
+                assert sub.tickers == [CONFIG.streaming_ticker]
+                async for tick in sub:
+                    rows.append(tick)
+                    if len(rows) >= 1:
+                        break
+
+        try:
+            await asyncio.wait_for(collect_ticks(), timeout=20)
+        except asyncio.TimeoutError:
+            pytest.skip(f"No conflated ticks received from {CONFIG.streaming_ticker} within timeout")
+
+        assert rows, f"Expected conflated streaming ticks from {CONFIG.streaming_ticker}"
+        assert rows[0].get("MKTDATA_EVENT_TYPE") in {"SUMMARY", "QUOTE", "TRADE"}
+        logger.info(f"  Got conflated tick: {rows[0]}")
+
+
+    @pytest.mark.asyncio
     async def test_unsubscribe_wakes_pending_iteration(self):
         """Stream: unsubscribe completes even when __anext__ is pending."""
         from xbbg import asubscribe
@@ -1757,69 +1806,171 @@ class TestArequest:
 
 
 class TestVwap:
-    """Tests for avwap() - streaming VWAP.
+    """Tests for avwap() - streaming Market VWAP."""
 
-    VWAP subscription may require specific Bloomberg entitlements.
-    rc=131077 from blpapi_Session_subscribe indicates subscription failure.
-    """
+    @staticmethod
+    def _assert_vwap_payload(row: dict, expected_topic: str) -> None:
+        assert row.get("topic") == expected_topic
+        assert row.get("MKTDATA_EVENT_TYPE") is None, "mktvwap must not return regular mktdata events"
+        assert "VWAP" in row
+        assert "RT_VWAP_VOLUME" in row or "VWAP_TURNOVER_RT" in row or "VWAP_NUM_TRADES_RT" in row
 
     @pytest.mark.asyncio
     async def test_avwap_basic(self):
-        """VWAP: basic streaming VWAP."""
+        """VWAP: avwap normalizes tickers and returns VWAP-service payloads."""
         from xbbg import avwap
 
-        ticks = 0
+        expected_topic = f"//blp/mktvwap/ticker/{CONFIG.equity_single}"
+        rows = []
 
         async def collect():
-            nonlocal ticks
-            sub = await avwap(CONFIG.streaming_ticker)
-            async for tick in sub:
-                ticks += 1
-                if ticks >= 2:
+            async with await avwap(
+                CONFIG.equity_single,
+                start_time="10:00",
+                end_time="16:00",
+                raw=True,
+            ) as sub:
+                assert sub.tickers == [expected_topic]
+                async for batch in sub:
+                    rows.extend(batch.to_pylist())
+                    if rows:
+                        break
+
+        try:
+            await asyncio.wait_for(collect(), timeout=30)
+        except asyncio.TimeoutError:
+            pytest.skip(f"No Market VWAP payload received from {CONFIG.equity_single} after 30s")
+        except Exception as exc:
+            skip_if_subscription_unavailable(exc, "Market VWAP")
+
+        assert rows, f"Expected Market VWAP payload from {CONFIG.equity_single}"
+        self._assert_vwap_payload(rows[0], expected_topic)
+        logger.info(f"  Got Market VWAP payload: {rows[0]}")
+
+    @pytest.mark.asyncio
+    async def test_asubscribe_mktvwap_live_contract(self):
+        """VWAP: generic asubscribe enforces Bloomberg's mktvwap topic contract."""
+        from xbbg import Service, blp
+
+        expected_topic = f"//blp/mktvwap/ticker/{CONFIG.equity_single}"
+        rows = []
+
+        async def collect():
+            async with await blp.asubscribe(
+                CONFIG.equity_single,
+                "VWAP",
+                service=Service.MKTVWAP,
+                options=["VWAP_START_TIME=10:00", "VWAP_END_TIME=16:00"],
+                all_fields=True,
+                tick_mode=True,
+            ) as sub:
+                assert sub.tickers == [expected_topic]
+                async for row in sub:
+                    rows.append(row)
                     break
 
         try:
-            await asyncio.wait_for(collect(), timeout=15)
+            await asyncio.wait_for(collect(), timeout=30)
         except asyncio.TimeoutError:
-            logger.warning(f"  VWAP timeout (got {ticks} ticks)")
-        except RuntimeError as e:
-            if "subscribe failed" in str(e):
-                pytest.skip(f"VWAP subscription not available (entitlement): {e}")
-            raise
+            pytest.skip(f"No generic Market VWAP payload received from {CONFIG.equity_single} after 30s")
+        except Exception as exc:
+            skip_if_subscription_unavailable(exc, "Market VWAP")
 
-        if ticks == 0:
-            pytest.skip(
-                "VWAP subscription produced 0 ticks after 15s "
-                "(likely requires specific Bloomberg entitlement for VWAP service)"
-            )
-        logger.info(f"  Got {ticks} VWAP ticks")
+        assert rows, f"Expected generic Market VWAP payload from {CONFIG.equity_single}"
+        self._assert_vwap_payload(rows[0], expected_topic)
+        logger.info(f"  Got generic Market VWAP payload: {rows[0]}")
 
 
 class TestMktbar:
     """Tests for amktbar() - streaming market bars."""
 
+    @staticmethod
+    def _assert_market_bar_service_payload(row: dict, expected_topic: str) -> None:
+        assert row.get("topic") == expected_topic
+        assert row.get("MKTDATA_EVENT_TYPE") is None, "mktbar must not return regular mktdata events"
+        assert "TIME" in row or "DATE_TIME" in row or "DATE" in row
+
+    @staticmethod
+    def _has_ohlc(row: dict) -> bool:
+        return bool({"OPEN", "HIGH", "LOW", "CLOSE"} & row.keys())
+
+    @staticmethod
+    def _assert_market_bar_ohlc(row: dict) -> None:
+        assert {"OPEN", "HIGH", "LOW", "CLOSE"} & row.keys(), f"Expected OHLC bar fields in {sorted(row)}"
+        assert "VOLUME" in row or "NUMBER_OF_TICKS" in row
+
     @pytest.mark.asyncio
     async def test_amktbar_basic(self):
-        """MKTBAR: streaming bars."""
+        """MKTBAR: amktbar normalizes tickers and returns bar-shaped payloads."""
         from xbbg import amktbar
 
-        bars = 0
+        expected_topic = f"//blp/mktbar/ticker/{CONFIG.mktbar_ticker}"
+        rows = []
 
         async def collect():
-            nonlocal bars
-            sub = await amktbar(CONFIG.streaming_ticker, interval=1)
-            async for bar in sub:
-                bars += 1
-                if bars >= 2:
-                    break
+            async with await amktbar(CONFIG.mktbar_ticker, bar_size=1, raw=True) as sub:
+                assert sub.tickers == [expected_topic]
+                async for batch in sub:
+                    rows.extend(batch.to_pylist())
+                    if any(self._has_ohlc(row) for row in rows):
+                        break
 
         try:
-            await asyncio.wait_for(collect(), timeout=15)
+            await asyncio.wait_for(collect(), timeout=30)
         except asyncio.TimeoutError:
-            logger.warning(f"  Mktbar timeout (got {bars} bars)")
+            if not rows:
+                pytest.skip(f"No market bars received from {CONFIG.mktbar_ticker} after 30s")
+        except Exception as exc:
+            skip_if_subscription_unavailable(exc, "Market Bar")
 
-        assert bars >= 1, f"Expected market bars from {CONFIG.streaming_ticker} (ES1 trades ~23h/day), got 0 after 15s"
-        logger.info(f"  Got {bars} market bars")
+        assert rows, f"Expected market bars from {CONFIG.mktbar_ticker}"
+        for row in rows:
+            self._assert_market_bar_service_payload(row, expected_topic)
+        ohlc_rows = [row for row in rows if self._has_ohlc(row)]
+        if not ohlc_rows:
+            pytest.skip(f"Only interval/end market-bar messages received from {CONFIG.mktbar_ticker}")
+        self._assert_market_bar_ohlc(ohlc_rows[0])
+        logger.info(f"  Got mktbar payload: {ohlc_rows[0]}")
+
+    @pytest.mark.asyncio
+    async def test_asubscribe_mktbar_live_contract(self):
+        """MKTBAR: generic asubscribe enforces Bloomberg's mktbar topic contract."""
+        from xbbg import Service, blp
+
+        expected_topic = f"//blp/mktbar/ticker/{CONFIG.mktbar_ticker}"
+        rows = []
+
+        async def collect():
+            async with await blp.asubscribe(
+                CONFIG.mktbar_ticker,
+                "LAST_PRICE",
+                service=Service.MKTBAR,
+                options=["bar_size=1"],
+                all_fields=True,
+                tick_mode=True,
+            ) as sub:
+                assert sub.tickers == [expected_topic]
+                async for row in sub:
+                    rows.append(row)
+                    if self._has_ohlc(row):
+                        break
+
+        try:
+            await asyncio.wait_for(collect(), timeout=30)
+        except asyncio.TimeoutError:
+            if not rows:
+                pytest.skip(f"No generic market-bar payload received from {CONFIG.mktbar_ticker} after 30s")
+        except Exception as exc:
+            skip_if_subscription_unavailable(exc, "Market Bar")
+
+        assert rows, f"Expected generic market-bar payload from {CONFIG.mktbar_ticker}"
+        for row in rows:
+            self._assert_market_bar_service_payload(row, expected_topic)
+        ohlc_rows = [row for row in rows if self._has_ohlc(row)]
+        if not ohlc_rows:
+            pytest.skip(f"Only generic interval/end market-bar messages received from {CONFIG.mktbar_ticker}")
+        self._assert_market_bar_ohlc(ohlc_rows[0])
+        logger.info(f"  Got generic mktbar payload: {ohlc_rows[0]}")
 
 
 class TestDepth:

--- a/py-xbbg/tests/test_streaming_api.py
+++ b/py-xbbg/tests/test_streaming_api.py
@@ -34,6 +34,9 @@ class TestAsubscribeSignature:
         assert "options" in params
         assert params["options"].default is None
 
+        assert "conflate" in params
+        assert params["conflate"].default is False
+
         assert "tick_mode" in params
         assert params["tick_mode"].default is False
 
@@ -75,6 +78,9 @@ class TestAstreamSignature:
         assert "all_fields" in params
         assert params["all_fields"].default is False
 
+        assert "conflate" in params
+        assert params["conflate"].default is False
+
 
 class TestStreamSignature:
     """Verify stream() also has the new params."""
@@ -101,6 +107,9 @@ class TestStreamSignature:
         assert "all_fields" in params
         assert params["all_fields"].default is False
 
+        assert "conflate" in params
+        assert params["conflate"].default is False
+
 
 class TestStreamingServiceHelpersSignature:
     """avwap / amktbar / adepth / achains forward all_fields."""
@@ -108,10 +117,433 @@ class TestStreamingServiceHelpersSignature:
     def test_all_fields_kwarg_defaults(self):
         from xbbg.blp import achains, adepth, amktbar, avwap
 
-        for fn in (avwap, amktbar, adepth, achains):
+        for fn in (adepth, achains):
             sig = inspect.signature(fn)
             assert "all_fields" in sig.parameters
             assert sig.parameters["all_fields"].default is False
+
+        for fn in (avwap, amktbar):
+            sig = inspect.signature(fn)
+            assert "all_fields" in sig.parameters
+            assert sig.parameters["all_fields"].default is True
+
+
+class TestVwapContract:
+    """Verify Market VWAP helpers use Bloomberg's required subscription shape."""
+
+    def _install_fake_engine(self, monkeypatch, captured: dict[str, object]):
+        import xbbg.blp as blp_module
+
+        class FakePySubscription:
+            tickers = ["//blp/mktvwap/ticker/IBM US Equity"]
+            failed_tickers = []
+            failures = []
+            topic_states = [("//blp/mktvwap/ticker/IBM US Equity", "pending", 1)]
+            session_status = {
+                "state": "up",
+                "last_change_us": 1,
+                "disconnect_count": 0,
+                "reconnect_count": 0,
+            }
+            admin_status = {
+                "slow_consumer_warning_active": False,
+                "slow_consumer_warning_count": 0,
+                "slow_consumer_cleared_count": 0,
+                "data_loss_count": 0,
+                "last_warning_us": None,
+                "last_cleared_us": None,
+                "last_data_loss_us": None,
+            }
+            service_status = []
+            events = []
+            fields = ["VWAP"]
+            is_active = True
+            all_failed = False
+            stats = {
+                "messages_received": 0,
+                "dropped_batches": 0,
+                "batches_sent": 0,
+                "slow_consumer": False,
+                "data_loss_events": 0,
+                "last_message_us": 0,
+                "last_data_loss_us": 0,
+                "effective_overflow_policy": "drop_newest",
+            }
+
+            def __init__(self):
+                self.added: list[list[str]] = []
+
+            async def add(self, tickers):
+                self.added.append(tickers)
+
+        fake_sub = FakePySubscription()
+
+        class FakeEngine:
+            async def subscribe_with_options(self, service, tickers, fields, options, **kwargs):
+                captured.update(
+                    {
+                        "service": service,
+                        "tickers": tickers,
+                        "fields": fields,
+                        "options": options,
+                        **kwargs,
+                    }
+                )
+                return fake_sub
+
+        monkeypatch.setattr(blp_module, "_get_engine", lambda: FakeEngine())
+        return blp_module, fake_sub
+
+    def test_avwap_signature_uses_vwap_only_contract(self):
+        from xbbg.blp import avwap
+
+        sig = inspect.signature(avwap)
+        assert "fields" not in sig.parameters
+        assert sig.parameters["all_fields"].default is True
+
+    def test_avwap_builds_explicit_market_vwap_subscription(self, monkeypatch):
+        from xbbg.services import Service
+
+        captured: dict[str, object] = {}
+        blp_module, fake_sub = self._install_fake_engine(monkeypatch, captured)
+
+        sub = asyncio.run(
+            blp_module.avwap(
+                ["IBM US Equity", "//blp/mktvwap/ticker/MSFT US Equity"],
+                start_time="10:00",
+                end_time="16:00",
+            )
+        )
+
+        assert captured["service"] == Service.MKTVWAP.value
+        assert captured["tickers"] == [
+            "//blp/mktvwap/ticker/IBM US Equity",
+            "//blp/mktvwap/ticker/MSFT US Equity",
+        ]
+        assert captured["fields"] == ["VWAP"]
+        assert captured["options"] == ["VWAP_START_TIME=10:00", "VWAP_END_TIME=16:00"]
+        assert captured["all_fields"] is True
+
+        asyncio.run(sub.add("AAPL US Equity"))
+        assert fake_sub.added == [["//blp/mktvwap/ticker/AAPL US Equity"]]
+
+    def test_asubscribe_mktvwap_normalizes_topics_and_validates_contract(self, monkeypatch):
+        from xbbg.services import Service
+
+        captured: dict[str, object] = {}
+        blp_module, fake_sub = self._install_fake_engine(monkeypatch, captured)
+
+        sub = asyncio.run(
+            blp_module.asubscribe(
+                "IBM US Equity",
+                "VWAP",
+                service=Service.MKTVWAP,
+                options=["VWAP_START_TIME=10:00", "VWAP_END_TIME=16:00"],
+                all_fields=True,
+            )
+        )
+
+        assert captured["service"] == Service.MKTVWAP.value
+        assert captured["tickers"] == ["//blp/mktvwap/ticker/IBM US Equity"]
+        assert captured["fields"] == ["VWAP"]
+        assert captured["options"] == ["VWAP_START_TIME=10:00", "VWAP_END_TIME=16:00"]
+        assert captured["all_fields"] is True
+
+        asyncio.run(sub.add("MSFT US Equity"))
+        assert fake_sub.added == [["//blp/mktvwap/ticker/MSFT US Equity"]]
+
+    def test_mktvwap_rejects_invalid_contract_inputs(self):
+        from xbbg.blp import asubscribe, avwap
+        from xbbg.services import Service
+
+        with pytest.raises(ValueError, match="market-VWAP topic"):
+            asyncio.run(avwap("//blp/mktdata/ticker/IBM US Equity"))
+
+        with pytest.raises(ValueError, match="VWAP"):
+            asyncio.run(
+                asubscribe(
+                    "IBM US Equity",
+                    ["RT_PX_VWAP"],
+                    service=Service.MKTVWAP,
+                )
+            )
+
+
+class TestMktbarContract:
+    """Verify market-bar helpers use Bloomberg's required subscription shape."""
+
+    def _install_fake_engine(self, monkeypatch, captured: dict[str, object]):
+        import xbbg.blp as blp_module
+
+        class FakePySubscription:
+            tickers = ["//blp/mktbar/ticker/ES1 Index"]
+            failed_tickers = []
+            failures = []
+            topic_states = [("//blp/mktbar/ticker/ES1 Index", "pending", 1)]
+            session_status = {
+                "state": "up",
+                "last_change_us": 1,
+                "disconnect_count": 0,
+                "reconnect_count": 0,
+            }
+            admin_status = {
+                "slow_consumer_warning_active": False,
+                "slow_consumer_warning_count": 0,
+                "slow_consumer_cleared_count": 0,
+                "data_loss_count": 0,
+                "last_warning_us": None,
+                "last_cleared_us": None,
+                "last_data_loss_us": None,
+            }
+            service_status = []
+            events = []
+            fields = ["LAST_PRICE"]
+            is_active = True
+            all_failed = False
+            stats = {
+                "messages_received": 0,
+                "dropped_batches": 0,
+                "batches_sent": 0,
+                "slow_consumer": False,
+                "data_loss_events": 0,
+                "last_message_us": 0,
+                "last_data_loss_us": 0,
+                "effective_overflow_policy": "drop_newest",
+            }
+
+            def __init__(self):
+                self.added: list[list[str]] = []
+                self.removed: list[list[str]] = []
+
+            async def add(self, tickers):
+                self.added.append(tickers)
+
+            async def remove(self, tickers):
+                self.removed.append(tickers)
+
+        fake_sub = FakePySubscription()
+
+        class FakeEngine:
+            async def subscribe_with_options(self, service, tickers, fields, options, **kwargs):
+                captured.update(
+                    {
+                        "service": service,
+                        "tickers": tickers,
+                        "fields": fields,
+                        "options": options,
+                        **kwargs,
+                    }
+                )
+                return fake_sub
+
+        monkeypatch.setattr(blp_module, "_get_engine", lambda: FakeEngine())
+        return blp_module, fake_sub
+
+    def test_amktbar_signature_uses_bar_size(self):
+        from xbbg.blp import amktbar
+
+        sig = inspect.signature(amktbar)
+        assert "bar_size" in sig.parameters
+        assert sig.parameters["bar_size"].default == 1
+        assert "interval" not in sig.parameters
+
+    def test_amktbar_builds_explicit_market_bar_subscription(self, monkeypatch):
+        from xbbg.services import Service
+
+        captured: dict[str, object] = {}
+        blp_module, fake_sub = self._install_fake_engine(monkeypatch, captured)
+
+        sub = asyncio.run(
+            blp_module.amktbar(
+                ["ES1 Index", "/figi/BBG000JB5HR2", "isin/GB00B16GWD56 LN"],
+                bar_size=5,
+                start_time="13:30",
+                end_time="20:00",
+            )
+        )
+
+        assert captured["service"] == Service.MKTBAR.value
+        assert captured["tickers"] == [
+            "//blp/mktbar/ticker/ES1 Index",
+            "//blp/mktbar/figi/BBG000JB5HR2",
+            "//blp/mktbar/isin/GB00B16GWD56 LN",
+        ]
+        assert captured["fields"] == ["LAST_PRICE"]
+        assert captured["options"] == ["bar_size=5", "start_time=13:30", "end_time=20:00"]
+        assert captured["all_fields"] is True
+
+        asyncio.run(sub.add("EURUSD Curncy"))
+        asyncio.run(sub.remove("/figi/BBG000JB5HR2"))
+        assert fake_sub.added == [["//blp/mktbar/ticker/EURUSD Curncy"]]
+        assert fake_sub.removed == [["//blp/mktbar/figi/BBG000JB5HR2"]]
+
+    def test_asubscribe_mktbar_normalizes_topics_and_validates_contract(self, monkeypatch):
+        from xbbg.services import Service
+
+        captured: dict[str, object] = {}
+        blp_module, fake_sub = self._install_fake_engine(monkeypatch, captured)
+
+        sub = asyncio.run(
+            blp_module.asubscribe(
+                "ES1 Index",
+                "LAST_PRICE",
+                service=Service.MKTBAR,
+                options=["bar_size=1"],
+                all_fields=True,
+            )
+        )
+
+        assert captured["service"] == Service.MKTBAR.value
+        assert captured["tickers"] == ["//blp/mktbar/ticker/ES1 Index"]
+        assert captured["fields"] == ["LAST_PRICE"]
+        assert captured["options"] == ["bar_size=1"]
+        assert captured["all_fields"] is True
+
+        asyncio.run(sub.add("ticker/EURUSD Curncy"))
+        assert fake_sub.added == [["//blp/mktbar/ticker/EURUSD Curncy"]]
+
+    def test_mktbar_rejects_invalid_contract_inputs(self):
+        from xbbg.blp import amktbar, asubscribe
+        from xbbg.services import Service
+
+        with pytest.raises(ValueError, match="bar_size"):
+            asyncio.run(amktbar("ES1 Index", bar_size=0))
+
+        with pytest.raises(ValueError, match="market-bar topic"):
+            asyncio.run(amktbar("//blp/mktdata/ticker/ES1 Index"))
+
+        with pytest.raises(ValueError, match="LAST_PRICE"):
+            asyncio.run(
+                asubscribe(
+                    "ES1 Index",
+                    ["OPEN"],
+                    service=Service.MKTBAR,
+                    options=["bar_size=1"],
+                )
+            )
+
+        with pytest.raises(ValueError, match="bar_size"):
+            asyncio.run(asubscribe("ES1 Index", "LAST_PRICE", service=Service.MKTBAR))
+
+        for invalid_option in (["bar_size"], ["bar_size="], ["bar_size=0"], ["bar_size=1441"], ["bar_size=abc"]):
+            with pytest.raises(ValueError, match="bar_size"):
+                asyncio.run(
+                    asubscribe(
+                        "ES1 Index",
+                        "LAST_PRICE",
+                        service=Service.MKTBAR,
+                        options=invalid_option,
+                    )
+                )
+
+
+class TestConflatedMarketDataContract:
+    """Verify mktdata conflation is exposed as a typed subscription option."""
+
+    def _install_fake_engine(self, monkeypatch, captured: dict[str, object]):
+        import xbbg.blp as blp_module
+
+        class FakePySubscription:
+            tickers = ["ES1 Index"]
+            failed_tickers = []
+            failures = []
+            topic_states = [("ES1 Index", "pending", 1)]
+            session_status = {
+                "state": "up",
+                "last_change_us": 1,
+                "disconnect_count": 0,
+                "reconnect_count": 0,
+            }
+            admin_status = {
+                "slow_consumer_warning_active": False,
+                "slow_consumer_warning_count": 0,
+                "slow_consumer_cleared_count": 0,
+                "data_loss_count": 0,
+                "last_warning_us": None,
+                "last_cleared_us": None,
+                "last_data_loss_us": None,
+            }
+            service_status = []
+            events = []
+            fields = ["BID", "ASK"]
+            is_active = True
+            all_failed = False
+            stats = {
+                "messages_received": 0,
+                "dropped_batches": 0,
+                "batches_sent": 0,
+                "slow_consumer": False,
+                "data_loss_events": 0,
+                "last_message_us": 0,
+                "last_data_loss_us": 0,
+                "effective_overflow_policy": "drop_newest",
+            }
+
+        class FakeEngine:
+            async def subscribe_with_options(self, service, tickers, fields, options, **kwargs):
+                captured.update(
+                    {
+                        "service": service,
+                        "tickers": tickers,
+                        "fields": fields,
+                        "options": options,
+                        **kwargs,
+                    }
+                )
+                return FakePySubscription()
+
+        monkeypatch.setattr(blp_module, "_get_engine", lambda: FakeEngine())
+        return blp_module
+
+    def test_asubscribe_conflate_adds_mktdata_option(self, monkeypatch):
+        from xbbg.services import Service
+
+        captured: dict[str, object] = {}
+        blp_module = self._install_fake_engine(monkeypatch, captured)
+
+        sub = asyncio.run(
+            blp_module.asubscribe(
+                "ES1 Index",
+                ["BID", "ASK"],
+                conflate=True,
+                all_fields=True,
+            )
+        )
+
+        assert captured["service"] == Service.MKTDATA.value
+        assert captured["tickers"] == ["ES1 Index"]
+        assert captured["fields"] == ["BID", "ASK"]
+        assert captured["options"] == ["conflate"]
+        assert captured["all_fields"] is True
+        assert sub.tickers == ["ES1 Index"]
+
+    def test_conflate_normalizes_ampersand_and_avoids_duplicates(self, monkeypatch):
+        captured: dict[str, object] = {}
+        blp_module = self._install_fake_engine(monkeypatch, captured)
+
+        asyncio.run(
+            blp_module.asubscribe(
+                "ES1 Index",
+                ["BID", "ASK"],
+                options=["&conflate", "delayed"],
+                conflate=True,
+            )
+        )
+
+        assert captured["options"] == ["conflate", "delayed"]
+
+    def test_conflate_rejects_non_mktdata_service(self):
+        from xbbg.blp import asubscribe
+        from xbbg.services import Service
+
+        with pytest.raises(ValueError, match="//blp/mktdata"):
+            asyncio.run(asubscribe("IBM US Equity", "VWAP", service=Service.MKTVWAP, conflate=True))
+
+    def test_conflate_rejects_interval_option(self):
+        from xbbg.blp import asubscribe
+
+        with pytest.raises(ValueError, match="interval"):
+            asyncio.run(asubscribe("ES1 Index", ["BID", "ASK"], options=["interval=5"], conflate=True))
 
 
 class TestConfigValidation:
@@ -345,6 +777,7 @@ class TestBackwardCompatibility:
         new_params = [
             "service",
             "options",
+            "conflate",
             "tick_mode",
             "flush_threshold",
             "stream_capacity",


### PR DESCRIPTION
## Summary
- Align `//blp/mktbar` subscriptions with Bloomberg's documented explicit service topics, `LAST_PRICE` field contract, and `bar_size` option.
- Align `//blp/mktvwap` usage with explicit `//blp/mktvwap/ticker/...` topics and `VWAP` as the single requested field.
- Add typed conflated market-data options for Python and JS on `//blp/mktdata`.

Fixes #322

## Verification
- `uv run --no-sync python -m pytest py-xbbg/tests/test_streaming_api.py -q`
- `uvx ruff check py-xbbg/src/xbbg/blp.py py-xbbg/tests/test_streaming_api.py py-xbbg/tests/live/test_api.py`
- `npm run typecheck`
- `npm run test:smoke`
- `npm run lint`
- `git diff --check`
- Live Python conflate test
- Live JS conflate test
- Live Python VWAP/MKTBAR regressions (`4 passed`)
