### PR TITLE
fix(streaming): expose mktbar message type metadata

### DIFF
--- a/archive/docs/src/content/docs/python/guides/streaming.mdx
+++ b/archive/docs/src/content/docs/python/guides/streaming.mdx
@@ -246,9 +246,9 @@ Streaming real-time OHLCV bars via `//blp/mktbar`. Like `bdib()` but live as bar
 
 Bloomberg requires market-bar subscriptions to use explicit `//blp/mktbar/{identifier-type}/{identifier}` topics, request `LAST_PRICE` as the only field, and set `bar_size` in minutes. `amktbar()` handles that for you: plain tickers use the `ticker` topic type, identifier paths like `/figi/...` keep their identifier type, and already-qualified `//blp/mktbar/...` topics pass through unchanged.
 
-Market bars are event-driven. Bloomberg may emit `MarketBarStart`, intra-bar `MarketBarUpdate`, `MarketBarIntervalEnd`, and `MarketBarEnd` messages; no-trade intervals may not produce OHLC payloads until Bloomberg publishes an interval/end event.
+Market bars are event-driven. Bloomberg may emit `MarketBarStart`, intra-bar `MarketBarUpdate`, `MarketBarIntervalEnd`, and `MarketBarEnd` messages inside `SUBSCRIPTION_DATA` events; no-trade intervals may not produce OHLC payloads until Bloomberg publishes an interval/end event.
 
-Default output exposes the full top-level market-bar payload, including fields Bloomberg sends such as `TIME`, `DATE_TIME`, `OPEN`, `HIGH`, `LOW`, `CLOSE`, `VOLUME`, and `NUMBER_OF_TICKS`. The request field sent to Bloomberg remains `LAST_PRICE`.
+Default output exposes the full top-level market-bar payload, including fields Bloomberg sends such as `TIME`, `DATE_TIME`, `OPEN`, `HIGH`, `LOW`, `CLOSE`, `VOLUME`, and `NUMBER_OF_TICKS`. xbbg also exposes Bloomberg's market-bar message type as `SUBSCRIPTION_DATA` row metadata so callers can distinguish new bars from updates. The request field sent to Bloomberg remains `LAST_PRICE`.
 
 ```python
 # 1-minute bars (default bar_size)

--- a/crates/xbbg-async/src/engine/state/subscription.rs
+++ b/crates/xbbg-async/src/engine/state/subscription.rs
@@ -75,11 +75,14 @@ pub struct SubscriptionState {
     suppress_closed_warning: bool,
     /// Whether to append all top-level scalar fields Bloomberg exposes.
     capture_all_fields: bool,
+    /// Optional projected field for Bloomberg mktbar message kind (MarketBarStart/Update/End).
+    subscription_data_index: Option<FieldIndex>,
 }
 
 impl SubscriptionState {
     const EVENT_METADATA_FIELDS: [&'static str; 2] =
         ["MKTDATA_EVENT_TYPE", "MKTDATA_EVENT_SUBTYPE"];
+    const SUBSCRIPTION_DATA_FIELD: &'static str = "SUBSCRIPTION_DATA";
     // Bloomberg can publish date-or-time values here with invalid date parts;
     // any typed/string getter makes the SDK emit warnings, so capture nulls.
     const INVALID_DATEORTIME_FIELDS: [&'static str; 1] = ["LAST_UPDATE_ALL_SESSIONS_RT"];
@@ -140,6 +143,18 @@ impl SubscriptionState {
                 Arc::from(field),
             );
         }
+        let subscription_data_index = if topic.starts_with("//blp/mktbar/") {
+            Some(Self::push_field_if_new(
+                &mut field_strings,
+                &mut field_names,
+                &mut field_name_keys,
+                &mut invalid_dateortime_fields,
+                &mut field_kinds,
+                Arc::from(Self::SUBSCRIPTION_DATA_FIELD),
+            ))
+        } else {
+            None
+        };
 
         let metrics = Arc::new(SubscriptionMetrics {
             messages_received: Arc::new(AtomicU64::new(0)),
@@ -172,6 +187,7 @@ impl SubscriptionState {
             has_received_data: false,
             suppress_closed_warning: false,
             capture_all_fields,
+            subscription_data_index,
         }
     }
 
@@ -220,11 +236,15 @@ impl SubscriptionState {
     /// `SystemTime::now()` if not enabled.
     pub fn on_message(&mut self, msg: &Message) -> bool {
         let timestamp = msg.time_received_us().unwrap_or_else(Self::system_time_us);
+        let subscription_data = self
+            .subscription_data_index
+            .is_some()
+            .then(|| Arc::<str>::from(msg.message_type().as_str()));
         let elem = msg.elements();
         let values = if self.capture_all_fields {
-            self.extract_all_fields(&elem)
+            self.extract_all_fields(&elem, subscription_data.as_ref())
         } else {
-            self.extract_requested_fields(&elem)
+            self.extract_requested_fields(&elem, subscription_data.as_ref())
         };
 
         self.metrics
@@ -256,10 +276,19 @@ impl SubscriptionState {
             .unwrap_or(0)
     }
 
-    fn extract_requested_fields(&mut self, elem: &xbbg_core::Element<'_>) -> Vec<UpdateField> {
+    fn extract_requested_fields(
+        &mut self,
+        elem: &xbbg_core::Element<'_>,
+        subscription_data: Option<&Arc<str>>,
+    ) -> Vec<UpdateField> {
         let mut values = Vec::with_capacity(self.field_names.len());
         for idx in 0..self.field_names.len() {
-            let value = if self.invalid_dateortime_fields[idx] {
+            let value = if Some(idx as FieldIndex) == self.subscription_data_index {
+                subscription_data
+                    .cloned()
+                    .map(UpdateValue::Str)
+                    .unwrap_or(UpdateValue::Null)
+            } else if self.invalid_dateortime_fields[idx] {
                 UpdateValue::Null
             } else if let Some(field) = elem.get(&self.field_names[idx]) {
                 let datatype = field.datatype();
@@ -283,8 +312,13 @@ impl SubscriptionState {
         values
     }
 
-    fn extract_all_fields(&mut self, elem: &xbbg_core::Element<'_>) -> Vec<UpdateField> {
-        let mut values = Vec::with_capacity(elem.num_children());
+    fn extract_all_fields(
+        &mut self,
+        elem: &xbbg_core::Element<'_>,
+        subscription_data: Option<&Arc<str>>,
+    ) -> Vec<UpdateField> {
+        let mut values = Vec::with_capacity(elem.num_children() + 1);
+        self.push_subscription_data(&mut values, subscription_data);
         for child_idx in 0..elem.num_children() {
             let Some(child) = elem.get_at(child_idx) else {
                 continue;
@@ -321,6 +355,22 @@ impl SubscriptionState {
             values.push(UpdateField { index: idx, value });
         }
         values
+    }
+
+    fn push_subscription_data(
+        &mut self,
+        values: &mut Vec<UpdateField>,
+        subscription_data: Option<&Arc<str>>,
+    ) {
+        let Some(idx) = self.subscription_data_index else {
+            return;
+        };
+        let value = subscription_data
+            .cloned()
+            .map(UpdateValue::Str)
+            .unwrap_or(UpdateValue::Null);
+        self.observe_kind(idx, &value);
+        values.push(UpdateField { index: idx, value });
     }
 
     fn extract_child_value(
@@ -498,6 +548,33 @@ mod tests {
         for (field, name) in state.field_strings.iter().zip(state.field_names.iter()) {
             assert_eq!(name.as_str(), field.as_ref());
         }
+    }
+
+    #[test]
+    fn mktbar_topics_include_subscription_data_metadata() {
+        let (tx, _rx) = mpsc::channel(1);
+        let state = SubscriptionState::new(
+            "//blp/mktbar/ticker/EURUSD Curncy".to_string(),
+            vec!["LAST_PRICE".to_string()],
+            tx,
+            10,
+            false,
+        );
+
+        assert_eq!(
+            state
+                .field_strings
+                .iter()
+                .map(|s| s.to_string())
+                .collect::<Vec<_>>(),
+            vec![
+                "LAST_PRICE".to_string(),
+                "MKTDATA_EVENT_TYPE".to_string(),
+                "MKTDATA_EVENT_SUBTYPE".to_string(),
+                "SUBSCRIPTION_DATA".to_string(),
+            ]
+        );
+        assert_eq!(state.subscription_data_index, Some(3));
     }
 
     #[test]

--- a/py-xbbg/tests/live/test_api.py
+++ b/py-xbbg/tests/live/test_api.py
@@ -1888,6 +1888,10 @@ class TestMktbar:
         assert row.get("topic") == expected_topic
         assert row.get("MKTDATA_EVENT_TYPE") is None, "mktbar must not return regular mktdata events"
         assert "TIME" in row or "DATE_TIME" in row or "DATE" in row
+        subscription_data = row.get("SUBSCRIPTION_DATA")
+        assert isinstance(subscription_data, str) and subscription_data.startswith("MarketBar"), (
+            "mktbar must expose Bloomberg's market-bar subscription message type"
+        )
 
     @staticmethod
     def _has_ohlc(row: dict) -> bool:
@@ -1970,6 +1974,44 @@ class TestMktbar:
             pytest.skip(f"Only generic interval/end market-bar messages received from {CONFIG.mktbar_ticker}")
         self._assert_market_bar_ohlc(ohlc_rows[0])
         logger.info(f"  Got generic mktbar payload: {ohlc_rows[0]}")
+
+    @pytest.mark.asyncio
+    async def test_asubscribe_mktbar_subscription_data_filtered_fields(self):
+        """MKTBAR: filtered subscription output still exposes bar message kind."""
+        from xbbg import Service, blp
+
+        expected_topic = f"//blp/mktbar/ticker/{CONFIG.mktbar_ticker}"
+        rows = []
+
+        async def collect():
+            async with await blp.asubscribe(
+                CONFIG.mktbar_ticker,
+                "LAST_PRICE",
+                service=Service.MKTBAR,
+                options=["bar_size=1"],
+                tick_mode=True,
+            ) as sub:
+                assert sub.tickers == [expected_topic]
+                async for row in sub:
+                    rows.append(row)
+                    if isinstance(row.get("SUBSCRIPTION_DATA"), str):
+                        break
+
+        try:
+            await asyncio.wait_for(collect(), timeout=30)
+        except asyncio.TimeoutError:
+            if not rows:
+                pytest.skip(f"No filtered market-bar payload received from {CONFIG.mktbar_ticker} after 30s")
+        except Exception as exc:
+            skip_if_subscription_unavailable(exc, "Market Bar")
+
+        assert rows, f"Expected filtered market-bar payload from {CONFIG.mktbar_ticker}"
+        row = rows[-1]
+        assert row.get("topic") == expected_topic
+        subscription_data = row.get("SUBSCRIPTION_DATA")
+        assert isinstance(subscription_data, str) and subscription_data.startswith("MarketBar"), (
+            "filtered mktbar output must expose Bloomberg's market-bar subscription message type"
+        )
 
 
 class TestDepth:


### PR DESCRIPTION
## Summary
- expose Bloomberg market-bar message type metadata (`MarketBarStart`, `MarketBarUpdate`, etc.) as `SUBSCRIPTION_DATA` row metadata for `//blp/mktbar/...` subscriptions
- keep non-mktbar subscription schemas unchanged and avoid message-type allocation outside mktbar topics
- document that `SUBSCRIPTION_DATA` comes from Bloomberg subscription event/message metadata, not a scalar payload element
- add live coverage for both all-fields and filtered mktbar output

Fixes #322.

## Verification
- `cargo test -p xbbg-async subscription` (`7 passed`)
- `CI= uv run --all-extras pytest py-xbbg/tests/test_streaming_api.py -q` (`24 passed`)
- `CI= uv run --all-extras pytest py-xbbg/tests/live/test_api.py::TestMktbar -ra -v --tb=short` (`3 passed`)
- raw Python `blpapi` probe confirmed `Event.SUBSCRIPTION_DATA`, `msg.messageType()` values `MarketBarStart`/`MarketBarUpdate`, and no `SUBSCRIPTION_DATA` payload element
